### PR TITLE
Allow interacted lagged controls in panel and not checking rows

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -1,13 +1,27 @@
+struct PartialOLS{TF<:AbstractFloat}
+    X::Matrix{TF}
+    crossX::Matrix{TF}
+    coef::Matrix{TF}
+    resid::Matrix{TF}
+end
+
+function PartialOLS(T, NY, NX, NG, TF=Float64)
+    X = Matrix{TF}(undef, T, NX)
+    crossX = Matrix{TF}(undef, NX, NX)
+    coef = Matrix{TF}(undef, NX, NG*NY)
+    resid = Matrix{TF}(undef, T, NY)
+    return PartialOLS(X, crossX, coef, resid)
+end
+
 """
     LPData{TF<:AbstractFloat,TG<:Union{Vector,Nothing},TW<:Union{AbstractVector,Nothing}}
 
 Raw data collected for generating data matrices for local projection estimation.
 """
-struct LPData{TF<:AbstractFloat,TG<:Union{Vector,Nothing},TW<:Union{AbstractVector,Nothing}}
+struct LPData{TF<:AbstractFloat, TG<:Union{Vector,Nothing},
+        TW<:Union{AbstractVector,Nothing}, TE<:Union{BitVector,Nothing}}
     ys::Vector{Any}
-    xs::Vector{Any}
-    ws::Vector{Any}
-    sts::Union{Vector{Any},Nothing}
+    wgs::Vector{Any}
     fes::Vector{Any}
     clus::Vector{Any}
     pw::TW
@@ -15,23 +29,22 @@ struct LPData{TF<:AbstractFloat,TG<:Union{Vector,Nothing},TW<:Union{AbstractVect
     minhorz::Int
     subset::Union{BitVector,Nothing}
     Xfull::Matrix{TF}
-    esampleTfull::BitVector
+    esampleTfull::TE
     groups::TG
 end
 
-function _fillX!(X, esampleT, aux, xs, ws, sts, fes, clus, pw, nlag, horz, subset, TF)
+function _fillX!(X, esampleT::AbstractVector{Bool}, aux::AbstractVector{Bool},
+        xs, ws, sts, fes, clus, pw, nlag, horz, subset, TF)
     Tfull = size(ws[1],1)
     nx = length(xs)
     nw = length(ws)
     nfe = length(fes)
     nclu = length(clus)
-    if nx > 0
-        for j in 1:nx
-            v = view(vec(xs[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
-            subset === nothing || j > 1 || (esampleT .&= view(subset, nlag+1:Tfull-horz))
-            _esample!(esampleT, aux, v)
-            copyto!(view(X,esampleT,j), view(v,esampleT))
-        end
+    for j in 1:nx
+        v = view(vec(xs[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
+        subset === nothing || j > 1 || (esampleT .&= view(subset, nlag+1:Tfull-horz))
+        _esample!(esampleT, aux, v)
+        copyto!(view(X,esampleT,j), view(v,esampleT))
     end
     if sts === nothing
         for j in 1:nw
@@ -46,43 +59,68 @@ function _fillX!(X, esampleT, aux, xs, ws, sts, fes, clus, pw, nlag, horz, subse
         end
     else
         ns = length(sts)
-        ssts = Vector{AbstractVector}(undef, ns)
-        for j in 1:ns
-            v = view(vec(sts[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
-            _esample!(esampleT, aux, v)
-            ssts[j] = v
-        end
-        for j in 1:nw
-            for l in 1:nlag
-                for s in 1:ns
-                    v = view(vec(ws[j], subset, :x, horz, TF), nlag+1-l:Tfull-horz-l)
-                    subset === nothing || j > 1 ||
+        for s in 1:ns
+            sst = view(vec(sts[s], subset, :x, horz, TF), nlag+1:Tfull-horz)
+            _esample!(esampleT, aux, sst)
+            for j in 1:nw
+                wj = vec(ws[j], subset, :x, horz, TF)
+                for l in 1:nlag
+                    v = view(wj, nlag+1-l:Tfull-horz-l)
+                    subset === nothing || j > 1 || s > 1 ||
                         (esampleT .&= view(subset, nlag+1-l:Tfull-horz-l))
                     s > 1 || _esample!(esampleT, aux, v)
                     X[esampleT, nx+(l-1)*nw*ns+(j-1)*ns+s] .=
-                        view(ssts[s],esampleT) .* view(v,esampleT)
+                        view(sst,esampleT) .* view(v,esampleT)
                 end
             end
         end
     end
-    if nfe > 0
-        for j in 1:nfe
-            v = view(vec(fes[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
-            subset === nothing || j > 1 || (esampleT .&= view(subset, nlag+1:Tfull-horz))
-            _esample!(esampleT, aux, v)
-        end
+    for j in 1:nfe
+        v = view(vec(fes[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
+        subset === nothing || j > 1 || (esampleT .&= view(subset, nlag+1:Tfull-horz))
+        _esample!(esampleT, aux, v)
     end
-    if nclu > 0
-        for j in 1:nclu
-            v = view(vec(clus[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
-            subset === nothing || j > 1 || (esampleT .&= view(subset, nlag+1:Tfull-horz))
-            _esample!(esampleT, aux, v)
-        end
+    for j in 1:nclu
+        v = view(vec(clus[j], subset, :x, horz, TF), nlag+1:Tfull-horz)
+        subset === nothing || j > 1 || (esampleT .&= view(subset, nlag+1:Tfull-horz))
+        _esample!(esampleT, aux, v)
     end
     if pw !== nothing
         v = view(vec(pw, subset, :x, horz, TF), nlag+1:Tfull-horz)
         subset === nothing || (esampleT .&= view(subset, nlag+1:Tfull-horz))
         _esample!(esampleT, aux, v)
+    end
+end
+
+# A version that assumes all data rows are valid
+function _fillX!(X, xs, ws, sts, nlag, horz, TF)
+    Tfull = size(ws[1],1)
+    nx = length(xs)
+    nw = length(ws)
+    for j in 1:nx
+        v = view(vec(xs[j], nothing, :x, horz, TF), nlag+1:Tfull-horz)
+        copyto!(view(X,:,j), v)
+    end
+    if sts === nothing
+        for j in 1:nw
+            for l in 1:nlag
+                v = view(vec(ws[j], nothing, :x, horz, TF), nlag+1-l:Tfull-horz-l)
+                # Variables with the same lag are put together
+                copyto!(view(X,:,nx+(l-1)*nw+j), v)
+            end
+        end
+    else
+        ns = length(sts)
+        for s in 1:ns
+            sst = view(vec(sts[s], nothing, :x, horz, TF), nlag+1:Tfull-horz)
+            for j in 1:nw
+                wj = vec(ws[j], nothing, :x, horz, TF)
+                for l in 1:nlag
+                    v = view(wj, nlag+1-l:Tfull-horz-l)
+                    X[:, nx+(l-1)*nw*ns+(j-1)*ns+s] .= sst .* v
+                end
+            end
+        end
     end
 end
 
@@ -92,8 +130,8 @@ function _checklpdata(ys, ws, nlag)
     length(ws) > 0 || throw(ArgumentError("ws cannot be empty"))
 end
 
-function LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset,
-        groups::Nothing, TF=Float64)
+function LPData(ys, xs, ws, wgs, sts, fes, clus, pw, nlag, minhorz, subset,
+        groups::Nothing, checkrows, TF=Float64)
     _checklpdata(ys, ws, nlag)
     Tfull = size(ys[1],1)
     # Number of rows possibly involved in estimation
@@ -104,18 +142,23 @@ function LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset,
     T > nX || throw(ArgumentError(
         "not enough observations for nlag=$nlag and minhorz=$minhorz"))
     X = Matrix{TF}(undef, T, nX)
-    # Indicators for valid observations within the T rows
-    esampleT = trues(T)
-    # A cache for indicators
-    aux = BitVector(undef, T)
-    _fillX!(X, esampleT, aux, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset, TF)
-    sum(esampleT) > nX || throw(ArgumentError(
-        "not enough observations for nlag=$nlag and minhorz=$minhorz"))
-    return LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset, X, esampleT, groups)
+    if checkrows
+        # Indicators for valid observations within the T rows
+        esampleT = trues(T)
+        # A cache for indicators
+        aux = BitVector(undef, T)
+        _fillX!(X, esampleT, aux, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset, TF)
+        sum(esampleT) > nX || throw(ArgumentError(
+            "not enough observations for nlag=$nlag and minhorz=$minhorz"))
+    else
+        esampleT = nothing
+        _fillX!(X, xs, ws, sts, nlag, minhorz, TF)
+    end
+    return LPData(ys, wgs, fes, clus, pw, nlag, minhorz, subset, X, esampleT, groups)
 end
 
-function LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset,
-        groups::Vector, TF=Float64)
+function LPData(ys, xs, ws, wgs, sts, fes, clus, pw, nlag, minhorz, subset,
+        groups::Vector, checkrows, TF=Float64)
     _checklpdata(ys, ws, nlag)
     ng = length(groups)
     Tfull = size(ys[1],1)
@@ -127,30 +170,40 @@ function LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset,
     T > nX || throw(ArgumentError(
         "not enough observations for nlag=$nlag and minhorz=$minhorz"))
     X = Matrix{TF}(undef, T, nX)
-    # Indicators for valid observations within the T rows
-    esampleT = trues(T)
-    # A cache for indicators
-    aux = BitVector(undef, T)
+    if checkrows
+        # Indicators for valid observations within the T rows
+        esampleT = trues(T)
+        # A cache for indicators
+        aux = BitVector(undef, T)
+    else
+        esampleT = nothing
+    end
     r1 = 1
     for ids in groups
         Nid = length(ids)
         r2 = r1 + Nid - nlag - minhorz - 1
         gX = view(X, r1:r2, :)
-        gesampleT = view(esampleT, r1:r2)
-        gaux = view(aux, r1:r2)
-        r1 = r2 + 1
         gxs = map(x->view(x, ids), xs)
         gws = map(x->view(x, ids), ws)
         gsts = sts === nothing ? nothing : map(x->view(x, ids), sts)
         gfes = map(x->view(x, ids), fes)
         gclus = map(x->view(x, ids), clus)
         gpw = pw === nothing ? nothing : view(pw, ids)
-        gsubset = subset === nothing ? nothing : view(subset, ids)
-        _fillX!(gX, gesampleT, gaux, gxs, gws, gsts, gfes, gclus, gpw, nlag, minhorz, gsubset, TF)
+        if checkrows
+            gesampleT = view(esampleT, r1:r2)
+            gaux = view(aux, r1:r2)
+            gsubset = subset === nothing ? nothing : view(subset, ids)
+            _fillX!(gX, gesampleT, gaux, gxs, gws, gsts, gfes, gclus, gpw, nlag, minhorz, gsubset, TF)
+        else
+            _fillX!(gX, gxs, gws, gsts, nlag, minhorz, TF)
+        end
+        r1 = r2 + 1
     end
-    sum(esampleT) > nX || throw(ArgumentError(
-        "not enough observations for nlag=$nlag and minhorz=$minhorz"))
-    return LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset, X, esampleT, groups)
+    if checkrows
+        sum(esampleT) > nX || throw(ArgumentError(
+            "not enough observations for nlag=$nlag and minhorz=$minhorz"))
+    end
+    return LPData(ys, wgs, fes, clus, pw, nlag, minhorz, subset, X, esampleT, groups)
 end
 
 function _fillY!(Y, esampleT, aux, ys, nlag, horz, subset, isfirststage, TF)
@@ -168,50 +221,68 @@ function _fillY!(Y, esampleT, aux, ys, nlag, horz, subset, isfirststage, TF)
     end
 end
 
+function _fillY!(Y, ys, nlag, horz, isfirststage, TF)
+    Tfull = size(ys[1], 1)
+    for j in 1:size(Y,2)
+        if isfirststage
+            v = view(vec(ys[j], nothing, :x, horz, TF), nlag+1:Tfull-horz)
+        else
+            v = view(vec(ys[j], nothing, :y, horz, TF), nlag+horz+1:Tfull)
+        end
+        copyto!(view(Y,:,j), v)
+    end
+end
+
 # The simple case without the panel dimension
 function _makeYX(dt::LPData{TF,Nothing}, horz::Int, isfirststage::Bool=false) where TF
     ny = length(dt.ys)
     # Number of rows possibly involved in estimation when horz==minhorz
-    Tfull = length(dt.esampleTfull)
+    Tfull = size(dt.Xfull, 1)
     nshift = horz - dt.minhorz
     # Number of rows possibly involved in estimation for horz
     T = Tfull - nshift
     nX = size(dt.Xfull, 2)
     T > nX || throw(ArgumentError(
         "not enough observations for nlag=$nlag and horz=$horz"))
-    # Indicators for valid observations within the T rows
-    esampleT = dt.esampleTfull[1:T]
-    # A cache for indicators
-    aux = BitVector(undef, T)
-    # Construct matrices
     Y = Matrix{TF}(undef, T, ny)
-    _fillY!(Y, esampleT, aux, dt.ys, dt.nlag, horz, dt.subset, isfirststage, TF)
-    T1 = sum(esampleT)
-    if T1 < T
-        T1 > size(dt.Xfull,2) || throw(ArgumentError(
-            "not enough observations for nlag=$nlag and horz=$(horz)"))
-        Y = Y[esampleT, :]
-    end
-    X = Matrix{TF}(undef, T1, nX)
-    @inbounds for j in 1:nX
-        ir = 1
-        for i in 1:T
-            if esampleT[i]
-                X[ir,j] = dt.Xfull[i,j]
-                ir += 1
+    if dt.esampleTfull isa BitVector
+        # Indicators for valid observations within the T rows
+        esampleT = dt.esampleTfull[1:T]
+        # A cache for indicators
+        aux = BitVector(undef, T)
+        _fillY!(Y, esampleT, aux, dt.ys, dt.nlag, horz, dt.subset, isfirststage, TF)
+        T1 = sum(esampleT)
+        if T1 < T
+            T1 > size(dt.Xfull,2) || throw(ArgumentError(
+                "not enough observations for nlag=$nlag and horz=$(horz)"))
+            Y = Y[esampleT, :]
+        end
+        X = Matrix{TF}(undef, T1, nX)
+        @inbounds for j in 1:nX
+            ir = 1
+            for i in 1:T
+                if esampleT[i]
+                    X[ir,j] = dt.Xfull[i,j]
+                    ir += 1
+                end
             end
         end
+        T = T1
+    else
+        esampleT = nothing
+        _fillY!(Y, dt.ys, dt.nlag, horz, isfirststage, TF)
+        X = dt.Xfull[1:T,:]
     end
-    T = T1
-    return Y, X, nothing, uweights(T), T, esampleT, 0
+    return Y, X, Y, nothing, nothing, uweights(T), T, esampleT, 0
 end
 
 # The case for panel data
 # Need to additionally handle data for fixed effects, clusters and weights
+# May also need to partial out wgs if relevant
 function _makeYX(dt::LPData{TF,<:Vector}, horz::Int, isfirststage::Bool=false) where TF
     ny = length(dt.ys)
     # Number of rows possibly involved in estimation when horz==minhorz
-    Tfull = length(dt.esampleTfull)
+    Tfull = size(dt.Xfull, 1)
     nshift = horz - dt.minhorz
     ng = length(dt.groups)
     # Number of rows possibly involved in estimation for horz
@@ -219,12 +290,16 @@ function _makeYX(dt::LPData{TF,<:Vector}, horz::Int, isfirststage::Bool=false) w
     nX = size(dt.Xfull, 2)
     T > nX || throw(ArgumentError(
         "not enough observations for nlag=$nlag and horz=$horz"))
-    # Indicators for valid observations within the T rows
-    esampleT = BitVector(undef, T)
-    # A cache for indicators
-    aux = BitVector(undef, T)
-    # Construct matrices
     Y = Matrix{TF}(undef, T, ny)
+    checkrows = dt.esampleTfull isa BitVector
+    if checkrows
+        # Indicators for valid observations within the T rows
+        esampleT = BitVector(undef, T)
+        # A cache for indicators
+        aux = BitVector(undef, T)
+    else
+        esampleT = nothing
+    end
     r1 = 1
     i1 = 1
     for ids in dt.groups
@@ -232,96 +307,162 @@ function _makeYX(dt::LPData{TF,<:Vector}, horz::Int, isfirststage::Bool=false) w
         step = Nid - dt.nlag - horz - 1
         r2 = r1 + step
         i2 = i1 + step
-        # Indicators for valid observations within the T rows
-        gesampleT = view(esampleT, i1:i2)
-        gesampleT .= dt.esampleTfull[r1:r2]
-        gaux = view(aux, i1:i2)
         gY = view(Y, i1:i2, :)
+        gys = map(y->view(y, ids), dt.ys)
+        if checkrows
+            # Indicators for valid observations within the T rows
+            gesampleT = view(esampleT, i1:i2)
+            gesampleT .= dt.esampleTfull[r1:r2]
+            gaux = view(aux, i1:i2)
+            gsubset = dt.subset === nothing ? nothing : view(dt.subset, ids)
+            _fillY!(gY, gesampleT, gaux, gys, dt.nlag, horz, gsubset, isfirststage, TF)
+        else
+            _fillY!(gY, gys, dt.nlag, horz, isfirststage, TF)
+        end
         r1 = r2 + nshift + 1
         i1 = i2 + 1
-        gys = map(y->view(y, ids), dt.ys)
-        gsubset = dt.subset === nothing ? nothing : view(dt.subset, ids)
-        _fillY!(gY, gesampleT, gaux, gys, dt.nlag, horz, gsubset, isfirststage, TF)
     end
-    T1 = sum(esampleT)
-    if T1 < T
-        T1 > size(dt.Xfull,2) || throw(ArgumentError(
-            "not enough observations for nlag=$nlag and horz=$(horz)"))
-        Y = Y[esampleT, :]
-    end
-    X = Matrix{TF}(undef, T1, nX)
-    @inbounds for j in 1:nX
-        ir = 1
-        i1 = 1
-        k1 = 1
-        for ids in dt.groups
-            Nid = length(ids)
-            step = Nid - dt.nlag - horz - 1
-            i2 = i1 + step
-            for i in i1:i2
-                if esampleT[k1]
+    if checkrows
+        T1 = sum(esampleT)
+        if T1 < T
+            T1 > size(dt.Xfull,2) || throw(ArgumentError(
+                "not enough observations for nlag=$nlag and horz=$(horz)"))
+            Y = Y[esampleT, :]
+        end
+        X = Matrix{TF}(undef, T1, nX)
+        @inbounds for j in 1:nX
+            ir = 1
+            i1 = 1
+            k1 = 1
+            for ids in dt.groups
+                Nid = length(ids)
+                step = Nid - dt.nlag - horz - 1
+                i2 = i1 + step
+                for i in i1:i2
+                    if esampleT[k1]
+                        X[ir,j] = dt.Xfull[i,j]
+                        ir += 1
+                    end
+                    k1 += 1
+                end
+                i1 = i2 + nshift + 1
+            end
+        end
+        FE = FixedEffect[]
+        @inbounds for fe in dt.fes
+            vfe = Vector{eltype(fe)}(undef, T1)
+            ir = 1
+            k1 = 1
+            for ids in dt.groups
+                i1 = ids[1] + dt.nlag
+                i2 = ids[end] - horz
+                for i in i1:i2
+                    if esampleT[k1]
+                        vfe[ir] = fe[i]
+                        ir += 1
+                    end
+                    k1 += 1
+                end
+            end
+            push!(FE, FixedEffect(vfe))
+        end
+        CLU = GroupedArray[]
+        @inbounds for clu in dt.clus
+            vclu = Vector{eltype(clu)}(undef, T1)
+            ir = 1
+            k1 = 1
+            for ids in dt.groups
+                i1 = ids[1] + dt.nlag
+                i2 = ids[end] - horz
+                for i in i1:i2
+                    if esampleT[k1]
+                        vclu[ir] = clu[i]
+                        ir += 1
+                    end
+                    k1 += 1
+                end
+            end
+            push!(CLU, GroupedArray(vclu, sort=nothing))
+        end
+        if dt.pw !== nothing
+            W = Vector{TF}(undef, T1)
+            ir = 1
+            k1 = 1
+            @inbounds for ids in dt.groups
+                i1 = ids[1] + dt.nlag
+                i2 = ids[end] - horz
+                for i in i1:i2
+                    if esampleT[k1]
+                        W[ir] = dt.pw[i]
+                        ir += 1
+                    end
+                    k1 += 1
+                end
+            end
+            W = Weights(W)
+        else
+            W = uweights(T1)
+        end
+        T = T1
+    else
+        X = Matrix{TF}(undef, T, nX)
+        @inbounds for j in 1:nX
+            ir = 1
+            i1 = 1
+            for ids in dt.groups
+                Nid = length(ids)
+                step = Nid - dt.nlag - horz - 1
+                i2 = i1 + step
+                for i in i1:i2
                     X[ir,j] = dt.Xfull[i,j]
                     ir += 1
                 end
-                k1 += 1
+                i1 = i2 + nshift + 1
             end
-            i1 = i2 + nshift + 1
         end
-    end
-    FE = FixedEffect[]
-    @inbounds for fe in dt.fes
-        vfe = Vector{eltype(fe)}(undef, T1)
-        ir = 1
-        k1 = 1
-        for ids in dt.groups
-            i1 = ids[1] + dt.nlag
-            i2 = ids[end] - horz
-            for i in i1:i2
-                if esampleT[k1]
+        FE = FixedEffect[]
+        @inbounds for fe in dt.fes
+            vfe = Vector{eltype(fe)}(undef, T)
+            ir = 1
+            for ids in dt.groups
+                i1 = ids[1] + dt.nlag
+                i2 = ids[end] - horz
+                for i in i1:i2
                     vfe[ir] = fe[i]
                     ir += 1
                 end
-                k1 += 1
             end
+            push!(FE, FixedEffect(vfe))
         end
-        push!(FE, FixedEffect(vfe))
-    end
-    CLU = GroupedArray[]
-    @inbounds for clu in dt.clus
-        vclu = Vector{eltype(clu)}(undef, T1)
-        ir = 1
-        k1 = 1
-        for ids in dt.groups
-            i1 = ids[1] + dt.nlag
-            i2 = ids[end] - horz
-            for i in i1:i2
-                if esampleT[k1]
+        CLU = GroupedArray[]
+        @inbounds for clu in dt.clus
+            vclu = Vector{eltype(clu)}(undef, T)
+            ir = 1
+            for ids in dt.groups
+                i1 = ids[1] + dt.nlag
+                i2 = ids[end] - horz
+                for i in i1:i2
                     vclu[ir] = clu[i]
                     ir += 1
                 end
-                k1 += 1
             end
+            push!(CLU, GroupedArray(vclu, sort=nothing))
         end
-        push!(CLU, GroupedArray(vclu, sort=nothing))
-    end
-    if dt.pw !== nothing
-        W = Vector{TF}(undef, T1)
-        ir = 1
-        k1 = 1
-        @inbounds for ids in dt.groups
-            i1 = ids[1] + dt.nlag
-            i2 = ids[end] - horz
-            for i in i1:i2
-                if esampleT[k1]
+        if dt.pw !== nothing
+            W = Vector{TF}(undef, T)
+            ir = 1
+            @inbounds for ids in dt.groups
+                i1 = ids[1] + dt.nlag
+                i2 = ids[end] - horz
+                for i in i1:i2
                     W[ir] = dt.pw[i]
                     ir += 1
                 end
-                k1 += 1
             end
+            W = Weights(W)
+        else
+            W = uweights(T)
         end
-        W = Weights(W)
-    else
-        W = uweights(T1)
     end
     if isempty(FE)
         doffe = 0
@@ -344,8 +485,92 @@ function _makeYX(dt::LPData{TF,<:Vector}, horz::Int, isfirststage::Bool=false) w
             col .*= sqrt.(W)
         end
     end
-    T = T1
-    return Y, X, CLU, W, T, esampleT, doffe
+    if isempty(dt.wgs)
+        pt = nothing
+        Ypt = Y
+    else
+        Ypt = copy(Y)
+        gT = length(dt.groups[1]) - dt.nlag - horz
+        nwg = length(dt.wgs)
+        # Must add a constant even with panelid as fixed effect
+        gnx = nwg * dt.nlag + 1
+        gny = ny + nX
+        pt = PartialOLS(gT, gny, gnx, length(dt.groups), TF)
+        pt.X[:,1] .= one(TF)
+        for (g, ids) in enumerate(dt.groups)
+            i1 = ids[1] + dt.nlag
+            i2 = ids[end] - horz
+            for j in 1:nwg
+                for l in 1:dt.nlag
+                    # No transformation for variables in wgs
+                    v = view(dt.wgs[j], i1-l:i2-l)
+                    # Variables with the same lag are put together
+                    copyto!(view(pt.X,:,1+(l-1)*nwg+j), v)
+                end
+            end
+            gY = view(Ypt, 1+(g-1)*gT:g*gT, :)
+            copyto!(view(pt.resid, :, 1:ny), gY)
+            gX = view(X, 1+(g-1)*gT:g*gT, :)
+            copyto!(view(pt.resid, :, ny+1:gny), gX)
+            # Solve the partial OLS
+            coefg = view(pt.coef, :, 1+(g-1)*gny:g*gny)
+            mul!(coefg, pt.X', pt.resid)
+            mul!(pt.crossX, pt.X', pt.X)
+            ldiv!(cholesky!(pt.crossX), coefg)
+            mul!(pt.resid, pt.X, coefg, -1.0, 1.0)
+            # Replace the Y and X with residuals
+            copyto!(gY, view(pt.resid, :, 1:ny))
+            copyto!(gX, view(pt.resid, :, ny+1:gny))
+        end
+    end
+    return Y, X, Ypt, pt, CLU, W, T, esampleT, doffe
+end
+
+# Fitted values from first stage of 2SLS
+function _fillfitted(fitted, groups::Nothing, nY, nlag, Tfull, horz, esampleT::BitVector, Xb)
+    for i in 1:nY
+        copyto!(view(view(fitted[i], nlag+1:Tfull-horz), esampleT), view(Xb,:,i))
+    end
+end
+
+function _fillfitted(fitted, groups::Nothing, nY, nlag, Tfull, horz, esampleT::Nothing, Xb)
+    for i in 1:nY
+        copyto!(view(fitted[i], nlag+1:Tfull-horz), view(Xb,:,i))
+    end
+end
+
+function _fillfitted(fitted, groups::Vector, nY, nlag, Tfull, horz, esampleT::BitVector, Xb)
+    for i in 1:nY
+        i1 = 1
+        n1 = 1
+        for ids in groups
+            Nid = length(ids)
+            step = Nid - nlag - horz - 1
+            i2 = i1 + step
+            gesampleT = view(esampleT, i1:i2)
+            n2 = n1 + sum(gesampleT) - 1
+            i1 = i2 + 1
+            tar = view(fitted[i], ids)
+            src = view(view(Xb,:,i), n1:n2)
+            n1 = n2 + 1
+            copyto!(view(view(tar, nlag+1:Nid-horz), gesampleT), src)
+        end
+    end
+end
+
+function _fillfitted(fitted, groups::Vector, nY, nlag, Tfull, horz, esampleT::Nothing, Xb)
+    for i in 1:nY
+        i1 = 1
+        for ids in groups
+            Nid = length(ids)
+            step = Nid - nlag - horz - 1
+            i2 = i1 + step
+            tar = view(fitted[i], ids)
+            src = view(view(Xb,:,i), i1:i2)
+            i1 = i2 + 1
+            copyto!(view(tar, nlag+1:Nid-horz), src)
+        end
+    end
 end
 
 # Xendo is needed for computing residuals from 2SLS
@@ -356,6 +581,18 @@ function _makeXendo(dt::LPData{TF,Nothing}, esampleT::BitVector, horz, yfs::Vect
         yf = vec(yfs[j], dt.subset, :x, horz, TF)
         src = view(yf, dt.nlag+1:length(yf)-horz)
         copyto!(view(Xendo,:,j), view(src, esampleT))
+    end
+    return Xendo
+end
+
+function _makeXendo(dt::LPData{TF,Nothing}, esampleT::Nothing, horz, yfs::Vector) where TF
+    nyfs = length(yfs)
+    T = size(dt.Xfull, 1) - horz + dt.minhorz
+    Xendo = Matrix{TF}(undef, T, nyfs)
+    @inbounds for j in 1:nyfs
+        yf = vec(yfs[j], nothing, :x, horz, TF)
+        src = view(yf, dt.nlag+1:length(yf)-horz)
+        copyto!(view(Xendo,:,j), src)
     end
     return Xendo
 end
@@ -378,6 +615,26 @@ function _makeXendo(dt::LPData{TF,<:Vector}, esampleT::BitVector, horz, yfs::Vec
             copyto!(view(Xendo,k1:k2,j), view(src, gesampleT))
             i1 = i2 + 1
             k1 = k2 + 1
+        end
+    end
+    return Xendo
+end
+
+function _makeXendo(dt::LPData{TF,<:Vector}, esampleT::Nothing, horz, yfs::Vector) where TF
+    nyfs = length(yfs)
+    T = size(dt.Xfull, 1) - length(dt.groups) * (horz - dt.minhorz)
+    Xendo = Matrix{TF}(undef, T, nyfs)
+    @inbounds for j in 1:nyfs
+        yf = vec(yfs[j], nothing, :x, horz, TF)
+        i1 = 1
+        for ids in dt.groups
+            Nid = length(ids)
+            step = Nid - dt.nlag - horz - 1
+            i2 = i1 + step
+            gyf = view(yf, ids)
+            src = view(gyf, dt.nlag+1:length(gyf)-horz)
+            copyto!(view(Xendo,i1:i2,j), src)
+            i1 = i2 + 1
         end
     end
     return Xendo

--- a/src/data.jl
+++ b/src/data.jl
@@ -636,7 +636,7 @@ function _makeXendo(dt::LPData{TF,<:Vector}, esampleT::BitVector, horz, yfs::Vec
             k1 = k2 + 1
         end
     end
-    _feresiduals!(Xendo, FE, W)
+    isempty(FE) || _feresiduals!(Xendo, FE, W)
     W isa UnitWeights || (Xendo .*= sqrt.(W))
     return Xendo
 end
@@ -659,7 +659,7 @@ function _makeXendo(dt::LPData{TF,<:Vector}, esampleT::Nothing, horz, yfs::Vecto
             i1 = i2 + 1
         end
     end
-    _feresiduals!(Xendo, FE, W)
+    isempty(FE) || _feresiduals!(Xendo, FE, W)
     W isa UnitWeights || (Xendo .*= sqrt.(W))
     return Xendo
 end

--- a/src/lp.jl
+++ b/src/lp.jl
@@ -117,6 +117,7 @@ struct LocalProjectionResult{TE<:AbstractEstimator,
     ynames::Vector{VarName}
     xnames::Vector{VarName}
     wnames::Vector{VarName}
+    wgnames::Vector{VarName}
     stnames::Vector{VarName}
     fenames::Vector{VarName}
     lookupy::Dict{VarName,Int}
@@ -225,18 +226,29 @@ _checknames(names) = all(n isa VarIndex for n in names)
 _toname(data, name::Symbol) = name
 _toname(data, i::Integer) = Tables.columnnames(data)[i]
 
-function _getcols(data, ynames, xnames, wnames, states, fes, clunames, panelid, panelweight,
+function _getcols(data, ynames, xnames, wnames, wgnames,
+        states, fes, clunames, panelid, panelweight,
         addpanelidfe, addylag, nocons; TF=Float64)
     # The names must be iterable
     ynames isa VarIndex && (ynames = (ynames,))
     xnames isa VarIndex && (xnames = (xnames,))
     wnames isa VarIndex && (wnames = (wnames,))
+    wgnames isa VarIndex && (wgnames = (wgnames,))
     states isa VarIndex && (states = (states,))
     fes isa VarIndex && (fes = (fes,))
     argmsg = ", must contain either integers, `Symbol`s or `TransformedVar`s"
     _checknames(ynames) || throw(ArgumentError("invalid ynames"*argmsg))
     length(xnames)==0 || _checknames(xnames) || throw(ArgumentError("invalid xnames"*argmsg))
     length(wnames)==0 || _checknames(wnames) || throw(ArgumentError("invalid wnames"*argmsg))
+    length(wgnames)==0 || _checknames(wgnames) ||
+        throw(ArgumentError("invalid wgnames"*argmsg))
+    if length(wgnames) > 0
+        panelid === nothing && throw(ArgumentError(
+            "panelid must be specified when wgnames is specified"))
+        any(in(wgnames), wnames) && throw(ArgumentError(
+            "a name in wgnames cannot also be in wnames"))
+        any(x->x isa Cum, wgnames) && throw(ArgumentError("Cum is not allowed in wgnames"))
+    end
     states===nothing || _checknames(states) || throw(ArgumentError("invalid states"*argmsg))
     length(fes)==0 || _checknames(fes) || throw(ArgumentError("invalid fes"*argmsg))
 
@@ -244,21 +256,24 @@ function _getcols(data, ynames, xnames, wnames, states, fes, clunames, panelid, 
     ynames = VarName[_toname(data, n) for n in ynames]
     xnames = VarName[_toname(data, n) for n in xnames]
     wnames = VarName[_toname(data, n) for n in wnames]
+    wgnames = VarName[_toname(data, n) for n in wgnames]
     stnames = states === nothing ? VarName[] : VarName[_toname(data, n) for n in states]
     fenames = VarName[_toname(data, n) for n in fes]
     panelid === nothing || (panelid = _toname(data, panelid))
     panelweight === nothing || (panelweight = _toname(data, panelweight))
     !addpanelidfe || panelid === nothing || panelid in fenames || push!(fenames, panelid)
-    addylag && union!(wnames, ynames)
+    addylag && union!(wnames, setdiff(ynames, wgnames))
 
     ys = Any[getcolumn(data, n) for n in ynames]
     xs = Any[getcolumn(data, n) for n in xnames]
     ws = Any[getcolumn(data, n) for n in wnames]
+    wgs = Any[getcolumn(data, n) for n in wgnames]
     sts = states === nothing ? nothing : Any[getcolumn(data, n) for n in states]
     fes = Any[getcolumn(data, n) for n in fenames]
     clus = Any[getcolumn(data, n) for n in clunames]
 
-    if !nocons && isempty(fenames)
+    # Always include group-specific intercept when wgnames is specified
+    if !nocons && isempty(fenames) && isempty(wgnames)
         push!(xs, ones(TF, length(ys[1])))
         xnames = VarName[xnames..., :constant]
     end
@@ -266,40 +281,43 @@ function _getcols(data, ynames, xnames, wnames, states, fes, clunames, panelid, 
     groups = panelid === nothing ? nothing : _group(getcolumn(data, panelid))
     pw = panelweight === nothing ? nothing : getcolumn(data, panelweight)
 
-    return ynames, xnames, wnames, stnames, fenames, panelid, panelweight, states,
-        ys, xs, ws, sts, fes, clus, pw, groups
+    return ynames, xnames, wnames, wgnames, stnames, fenames, panelid, panelweight, states,
+        ys, xs, ws, wgs, sts, fes, clus, pw, groups
 end
 
 function _lp(dt::LPData, horz::Int, vce, yfs::Nothing, ix_iv)
-    Y, X, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
+    Y, X, _, pt, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
     dofr = T - size(X,2) - doffe
+    pt === nothing || (dofr -= (size(pt.X,2)-1) * length(dt.groups))
     m = OLS(Y, X, dofr)
     return coef(m), vcov(m, vce), T, m
 end
 
 function _lp(dt::LPData, horz::Int, vce, yfs::Vector, ix_iv)
-    Y, Xhat, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
+    Y, Xhat, _, pt, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
     Xendo = _makeXendo(dt, esampleT, horz, yfs)
     X = similar(Xhat)
     copyto!(view(X,:,ix_iv), Xendo)
     iexo = setdiff(1:size(X,2), ix_iv)
     copyto!(view(X,:,iexo), view(Xhat,:,iexo))
     dofr = T - size(X,2) - doffe
+    pt === nothing || (dofr -= (size(pt.X,2)-1) * length(dt.groups))
     m = TSLS(Y, Xhat, X, dofr)
     return coef(m), vcov(m, vce), T, m
 end
 
 function _lp(dt::LPData, horz::Int, vce::ClusterCovariance, yfs::Nothing, ix_iv)
-    Y, X, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
+    Y, X, _, pt, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
     vce = cluster(names(vce), (CLU...,))
     dofr = T - size(X,2) - doffe
+    pt === nothing || (dofr -= (size(pt.X,2)-1) * length(dt.groups))
     doftstat = minimum(nclusters(vce)) - 1
     m = OLS(Y, X, dofr, doftstat)
     return coef(m), vcov(m, vce), T, m
 end
 
 function _lp(dt::LPData, horz::Int, vce::ClusterCovariance, yfs::Vector, ix_iv)
-    Y, Xhat, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
+    Y, Xhat, _, pt, CLU, W, T, esampleT, doffe = _makeYX(dt, horz)
     Xendo = _makeXendo(dt, esampleT, horz, yfs)
     X = similar(Xhat)
     copyto!(view(X,:,ix_iv), Xendo)
@@ -307,13 +325,14 @@ function _lp(dt::LPData, horz::Int, vce::ClusterCovariance, yfs::Vector, ix_iv)
     copyto!(view(X,:,iexo), view(Xhat,:,iexo))
     vce = cluster(names(vce), (CLU...,))
     dofr = T - size(X,2) - doffe
+    pt === nothing || (dofr -= (size(pt.X,2)-1) * length(dt.groups))
     doftstat = minimum(nclusters(vce)) - 1
     m = TSLS(Y, Xhat, X, dofr, doftstat)
     return coef(m), vcov(m, vce), T, m
 end
 
-function _normalize!(data, normalize, xnames, xs, ws, sts, fes, pw, nlag, minhorz,
-        subset, groups; TF=Float64)
+function _normalize!(data, normalize, xnames, xs, ws, wgs, sts, fes, pw, nlag, minhorz,
+        subset, groups, checkrows; TF=Float64)
     snames = normalize isa Pair ? (normalize[1],) : (p[1] for p in normalize)
     ix_s = Vector{Int}(undef, length(snames))
     for (i, n) in enumerate(snames)
@@ -325,7 +344,8 @@ function _normalize!(data, normalize, xnames, xs, ws, sts, fes, pw, nlag, minhor
     nnames = normalize isa Pair ? (normalize[2],) : (p[2] for p in normalize)
     yn = Any[getcolumn(data, n) for n in nnames]
     # Data on clusters are not needed
-    dt = LPData(yn, xs, ws, sts, fes, Any[], pw, nlag, minhorz, subset, groups, TF)
+    dt = LPData(yn, xs, ws, wgs, sts, fes, Any[], pw, nlag, minhorz, subset, groups,
+        checkrows, TF)
     Bn, Vn, Tn, _ = _lp(dt, minhorz, nothing, nothing, nothing)
     normmults = TF[Bn[ix,i] for (i,ix) in enumerate(ix_s)]
     xs[ix_s] .*= normmults
@@ -334,58 +354,36 @@ function _normalize!(data, normalize, xnames, xs, ws, sts, fes, pw, nlag, minhor
     return normnames, normtars, normmults
 end
 
-_normalize!(data, normalize::Nothing, xnames, xs, ws, sts, fes, pw, nlag, minhorz, subset,
-    groups; TF=Float64) = (nothing, nothing, nothing)
+_normalize!(data, normalize::Nothing, xnames, xs, ws, wgs, sts, fes, pw, nlag, minhorz,
+    subset, groups, checkrows; TF=Float64) = (nothing, nothing, nothing)
 
-function _fillfitted(fitted, groups::Nothing, nY, nlag, Tfull, horz, esampleT, Xb)
-    for i in 1:nY
-        copyto!(view(view(fitted[i], nlag+1:Tfull-horz), esampleT), view(Xb,:,i))
-    end
-end
-
-function _fillfitted(fitted, groups::Vector, nY, nlag, Tfull, horz, esampleT, Xb)
-    for i in 1:nY
-        i1 = 1
-        n1 = 1
-        for ids in groups
-            Nid = length(ids)
-            step = Nid - nlag - horz - 1
-            i2 = i1 + step
-            gesampleT = view(esampleT, i1:i2)
-            n2 = n1 + sum(gesampleT) - 1
-            i1 = i2 + 1
-            tar = view(fitted[i], ids)
-            src = view(view(Xb,:,i), n1:n2)
-            n1 = n2 + 1
-            copyto!(view(view(tar, nlag+1:Nid-horz), gesampleT), src)
-        end
-    end
-end
-
-function _firststage(nendo, niv, ys, xs, ws, sts, fes, clus, pw, nlag::Int, horz::Int,
-        subset::Union{BitVector,Nothing}, groups, testweakiv, vce; TF=Float64)
-    dt = LPData(ys, xs, ws, sts, fes, clus, pw, nlag, horz, subset, groups, TF)
-    Y, X, CLU, W, T, esampleT, doffe = _makeYX(dt, horz, true)
+function _firststage(nendo, niv, ys, xs, ws, wgs, sts, fes, clus, pw, nlag::Int, horz::Int,
+        subset::Union{BitVector,Nothing}, groups, testweakiv, vce, checkrows; TF=Float64)
+    dt = LPData(ys, xs, ws, wgs, sts, fes, clus, pw, nlag, horz, subset, groups,
+        checkrows, TF)
+    Y, X, Ypt, pt, CLU, W, T, esampleT, doffe = _makeYX(dt, horz, true)
     # Get first-stage estimates
-    bf = X'Y
+    bf = X'Ypt
     ldiv!(cholesky!(X'X), bf)
     # Make the fitted values, need to have the same length as original data
-    Tfull = size(ys[1],1)
+    Tfull = size(ys[1], 1)
     nY = length(ys)
     fitted = ((fill(convert(TF, NaN), Tfull) for _ in 1:nY)...,)
+    # Same results as Y .- (Ypt .- X * bf) even with wgs
     Xb = X * bf
     # Need to rescale back to avoid multiplying weights twice
     pw === nothing || (Xb ./= sqrt.(W))
     _fillfitted(fitted, groups, nY, nlag, Tfull, horz, esampleT, Xb)
     if testweakiv
         # Adapted from FixedEffectModels.jl
-        Endores = mul!(Y, X, bf, -1.0, 1.0)
+        Endores = mul!(Ypt, X, bf, -1.0, 1.0)
         Xexo = view(X, :, niv+1:size(X,2))
         Z = X[:,1:niv]
         Pi2 = ldiv!(cholesky!(Symmetric(Xexo'Xexo)), Xexo'Z)
         Zres = mul!(Z, Xexo, Pi2, -1.0, 1.0)
         Pip = bf[1:niv,:]
         nX = size(X,2) + nendo - niv
+        pt === nothing || (nX += (size(pt.X,2)-1) * length(dt.groups))
         # Only allow heteroskedasticity-robust or cluster-robust VCE for rank test
         vcerank = vce isa ClusterCovariance ? cluster(names(vce), (CLU...,)) : robust()
         try
@@ -402,8 +400,8 @@ function _firststage(nendo, niv, ys, xs, ws, sts, fes, clus, pw, nlag::Int, horz
     return fitted, F_kp, p_kp
 end
 
-function _iv!(data, iv, firststagebyhorz, xnames, xs, ws, sts, fes, clus, pw,
-        nlag, minhorz, subset, groups, testweakiv, vce; TF=Float64)
+function _iv!(data, iv, firststagebyhorz, xnames, xs, ws, wgs, sts, fes, clus, pw,
+        nlag, minhorz, subset, groups, testweakiv, vce, checkrows; TF=Float64)
     endonames = iv[1]
     endonames isa VarIndex && (endonames = (endonames,))
     nendo = length(endonames)
@@ -428,8 +426,8 @@ function _iv!(data, iv, firststagebyhorz, xnames, xs, ws, sts, fes, clus, pw,
     if !firststagebyhorz
         any(x->x isa Cum, endonames) &&
             @warn "firststagebyhorz=false while endogenous variables contain Cum"
-        fitted, F_kp, p_kp = _firststage(nendo, niv, yfs, xfs, ws, sts,
-            fes, clus, pw, nlag, minhorz, subset, groups, testweakiv, vce; TF=TF)
+        fitted, F_kp, p_kp = _firststage(nendo, niv, yfs, xfs, ws, wgs, sts,
+            fes, clus, pw, nlag, minhorz, subset, groups, testweakiv, vce, checkrows; TF=TF)
         # Replace the endogenous variable with the fitted values
         xs[ix_iv] .= fitted
     else
@@ -440,13 +438,13 @@ function _iv!(data, iv, firststagebyhorz, xnames, xs, ws, sts, fes, clus, pw,
     return endonames, ivnames, ix_iv, yfs, xfs, F_kp, p_kp
 end
 
-_iv!(data, iv::Nothing, firststagebyhorz, xnames, xs, ws, sts, fes, clus, pw,
-    nlag, minhorz, subset, groups, testweakiv, vce; TF=Float64) =
+_iv!(data, iv::Nothing, firststagebyhorz, xnames, xs, ws, wgs, sts, fes, clus, pw,
+    nlag, minhorz, subset, groups, testweakiv, vce, checkrows; TF=Float64) =
         (nothing, nothing, nothing, nothing, nothing, nothing, nothing)
 
-function _est(::LeastSquaresLP, data, xnames, ys, xs, ws, sts, fes, clus, pw,
+function _est(::LeastSquaresLP, data, xnames, ys, xs, ws, wgs, sts, fes, clus, pw,
         nlag, minhorz, nhorz, vce, subset, groups,
-        iv, ix_iv, nendo, niv, yfs, xfs, firststagebyhorz, testweakiv; TF=Float64)
+        iv, ix_iv, nendo, niv, yfs, xfs, firststagebyhorz, testweakiv, checkrows; TF=Float64)
     ny = length(ys)
     nstate =sts === nothing ? 1 : length(sts)
     nr = length(xs) + length(ws)*nlag*nstate
@@ -456,7 +454,8 @@ function _est(::LeastSquaresLP, data, xnames, ys, xs, ws, sts, fes, clus, pw,
     M = Vector{OLS{TF}}(undef, nhorz)
     firststagebyhorz = iv !== nothing && firststagebyhorz
     if !firststagebyhorz && !any(x->x isa Cum, xs)
-        dt = LPData(ys, xs, ws, sts, fes, clus, pw, nlag, minhorz, subset, groups, TF)
+        dt = LPData(ys, xs, ws, wgs, sts, fes, clus, pw, nlag, minhorz, subset, groups,
+            checkrows, TF)
     end
     F_kps = firststagebyhorz && testweakiv ? Vector{Float64}(undef, nhorz) : nothing
     p_kps = firststagebyhorz && testweakiv ? Vector{Float64}(undef, nhorz) : nothing
@@ -464,16 +463,18 @@ function _est(::LeastSquaresLP, data, xnames, ys, xs, ws, sts, fes, clus, pw,
         i = h - minhorz + 1
         # Handle cases where all data need to be regenerated for each horizon
         if firststagebyhorz
-            fitted, F_kpsi, p_kpsi = _firststage(nendo, niv, yfs, xfs,
-                ws, sts, fes, clus, pw, nlag, h, subset, groups, testweakiv, vce; TF=TF)
+            fitted, F_kpsi, p_kpsi = _firststage(nendo, niv, yfs, xfs, ws, wgs, sts,
+                fes, clus, pw, nlag, h, subset, groups, testweakiv, vce, checkrows; TF=TF)
             if testweakiv
                 F_kps[i] = F_kpsi
                 p_kps[i] = p_kpsi
             end
             xs[ix_iv] .= fitted
-            dt = LPData(ys, xs, ws, sts, fes, clus, pw, nlag, h, subset, groups, TF)
+            dt = LPData(ys, xs, ws, wgs, sts, fes, clus, pw, nlag, h, subset, groups,
+                checkrows, TF)
         elseif any(x->x isa Cum, xs)
-            dt = LPData(ys, xs, ws, sts, fes, clus, pw, nlag, h, subset, groups, TF)
+            dt = LPData(ys, xs, ws, wgs, sts, fes, clus, pw, nlag, h, subset, groups,
+                checkrows, TF)
         end
         Bh, Vh, T[i], M[i] = _lp(dt, h, vce, yfs, ix_iv)
         B[:,:,i] = reshape(Bh, nr, ny, 1)
@@ -493,6 +494,7 @@ The input `data` must be `Tables.jl`-compatible.
 # Keywords
 - `xnames=()`: indices of contemporaneous regressors from `data`.
 - `wnames=()`: indices of lagged control variables from `data`.
+- `wgnames=()`: indices of lagged control variables from `data` that are interacted with `panelid`; only relevant with panel data.
 - `nlag::Int=4`: number of lags to be included for the lagged control variables.
 - `nhorz::Int=1`: total number of horizons to be estimated.
 - `minhorz::Int=0`: the minimum horizon involved in estimation.
@@ -507,12 +509,14 @@ The input `data` must be `Tables.jl`-compatible.
 - `panelweight::Union{Symbol,Integer,Nothing}=nothing`: weights across units in a panel.
 - `vce::CovarianceEstimator=HRVCE()`: the variance-covariance estimator.
 - `subset::Union{BitVector,Nothing}=nothing`: subset of `data` to be used for estimation.
+- `checkrows::Bool=true`: check and skip any invalid data rows (with `missing`, etc.).
+- `balancedpanel::Bool=false`: panel data are balanced (after excluding invlid data rows).
 - `addylag::Bool=true`: include lags of the outcome variable(s).
 - `nocons::Bool=false`: do not add the constant term.
 - `TF::Type=Float64`: numeric type used for estimation.
 """
 function lp(estimator, data, ynames;
-        xnames=(), wnames=(), nlag::Int=4, nhorz::Int=1, minhorz::Int=0,
+        xnames=(), wnames=(), wgnames=(), nlag::Int=4, nhorz::Int=1, minhorz::Int=0,
         normalize::Union{VarIndexPair,Vector{VarIndexPair},Nothing}=nothing,
         iv::Union{Pair,Nothing}=nothing, firststagebyhorz::Bool=false,
         testweakiv::Bool=true, states=nothing,
@@ -520,14 +524,16 @@ function lp(estimator, data, ynames;
         panelweight::Union{Symbol,Integer,Nothing}=nothing,
         vce::CovarianceEstimator=HRVCE(),
         subset::Union{BitVector,Nothing}=nothing,
+        checkrows::Bool=true, balancedpanel::Bool=false, 
         addylag::Bool=true, nocons::Bool=false, TF::Type=Float64)
 
     checktable(data)
 
     clunames = vce isa ClusterCovariance ? names(vce) : ()
 
-    ynames, xnames, wnames, stnames, fenames, panelid, panelweight, states, ys, xs, ws,
-        sts, fes, clus, pw, groups = _getcols(data, ynames, xnames, wnames, states,
+    ynames, xnames, wnames, wgnames, stnames, fenames, panelid, panelweight, states,
+        ys, xs, ws, wgs, sts, fes, clus, pw, groups =
+            _getcols(data, ynames, xnames, wnames, wgnames, states,
             fes, clunames, panelid, panelweight, addpanelidfe, addylag, nocons)
 
     if panelid === nothing
@@ -541,6 +547,13 @@ function lp(estimator, data, ynames;
         end
     end
 
+    if !isempty(wgs)
+        !checkrows && balancedpanel ||
+            throw(ArgumentError("require a balanced panel with no invalid rows"))
+    end
+    !checkrows && subset!==nothing && throw(ArgumentError(
+        "subset is not considered when checkrows=false"))
+
     if any(x->x isa Cum, ynames)
         addylag && @warn "addylag=true while outcome variables contain Cum"
     end
@@ -548,24 +561,24 @@ function lp(estimator, data, ynames;
     normalize !== nothing && iv !== nothing &&
         throw(ArgumentError("options normalize and iv cannot be specified at the same time"))
     normnames, normtars, normmults =
-        _normalize!(data, normalize, xnames, xs, ws, sts, fes, pw, nlag, minhorz, subset,
-            groups, TF=TF)
+        _normalize!(data, normalize, xnames, xs, ws, wgs, sts, fes, pw, nlag, minhorz,
+            subset, groups, checkrows, TF=TF)
     endonames, ivnames, ix_iv, yfs, xfs, F_kp, p_kp =
-        _iv!(data, iv, firststagebyhorz, xnames, xs, ws, sts, fes, clus, pw, nlag,
-            minhorz, subset, groups, testweakiv, vce, TF=TF)
+        _iv!(data, iv, firststagebyhorz, xnames, xs, ws, wgs, sts, fes, clus, pw, nlag,
+            minhorz, subset, groups, testweakiv, vce, checkrows, TF=TF)
     nendo = endonames === nothing ? 0 : length(endonames)
     niv = ivnames === nothing ? 0 : length(ivnames)
 
-    B, V, T, er, F_kps, p_kps = _est(estimator, data, xnames, ys, xs, ws, sts,
+    B, V, T, er, F_kps, p_kps = _est(estimator, data, xnames, ys, xs, ws, wgs, sts,
         fes, clus, pw, nlag, minhorz, nhorz, vce, subset, groups,
-        iv, ix_iv, nendo, niv, yfs, xfs, firststagebyhorz, testweakiv, TF=TF)
+        iv, ix_iv, nendo, niv, yfs, xfs, firststagebyhorz, testweakiv, checkrows, TF=TF)
 
     if firststagebyhorz
         F_kp, p_kp = F_kps, p_kps
     end
 
     return LocalProjectionResult(B, V, T, estimator, er, vce,
-        ynames, xnames, wnames, stnames, fenames,
+        ynames, xnames, wnames, wgnames, stnames, fenames,
         Dict{VarName,Int}(n=>i for (i,n) in enumerate(ynames)),
         Dict{VarName,Int}(n=>i for (i,n) in enumerate(xnames)),
         Dict{VarName,Int}(n=>i for (i,n) in enumerate(wnames)),
@@ -587,7 +600,8 @@ function lp(r::LocalProjectionResult{LeastSquaresLP}, vce::CovarianceEstimator)
         V[:,:,h] = reshape(vcov(r.estres.ms[h], vce), K, K, 1)
     end
     return LocalProjectionResult(r.B, V, r.T, r.est, r.estres, vce,
-        r.ynames, r.xnames, r.wnames, r.stnames, r.fenames, r.lookupy, r.lookupx, r.lookupw,
+        r.ynames, r.xnames, r.wnames, r.wgnames, r.stnames, r.fenames,
+        r.lookupy, r.lookupx, r.lookupw,
         r.panelid, r.panelweight, r.nlag, r.minhorz, r.subset,
         r.normnames, r.normtars, r.normmults,
         r.endonames, r.ivnames, r.firststagebyhorz, r.F_kp, r.p_kp, r.nocons)
@@ -601,8 +615,9 @@ function _varinfo(r::LocalProjectionResult, halfwidth::Int)
     namex = "Regressor"*(length(r.xnames) > 1 ? "s" : "")
     xs = join(r.xnames, " ")
     namex = length(namex) + length(xs) > halfwidth ? (namex,) : namex
-    namew = "Lagged control"*(length(r.wnames) > 1 ? "s" : "")
-    ws = join(r.wnames, " ")
+    wnames = vcat(r.wnames, r.wgnames)
+    namew = "Lagged control"*(length(wnames) > 1 ? "s" : "")
+    ws = join(wnames, " ")
     namew = length(namew) + length(ws) > halfwidth ? (namew,) : namew
     info = Pair[
         "Outcome variable"*(length(r.ynames) > 1 ? "s" : "") => join(r.ynames, " "),
@@ -633,11 +648,15 @@ function _panelinfo(r::LocalProjectionResult{<:Any,<:Any,<:Any,<:Any}, halfwidth
     namefe = "Fixed effects"
     fes = join(r.fenames, " ")
     namefe = length(namefe) + length(fes) > halfwidth ? (namefe,) : namefe
+    namewg = "Interacted Lagged control"*(length(r.wgnames) > 1 ? "s" : "")
+    wgs = join(r.wgnames, " ")
+    namewg = length(namewg) + length(wgs) > halfwidth ? (namewg,) : namewg
     info = Pair[
         "Unit ID" => r.panelid,
         "Weights" => r.panelweight === nothing ? "(uniform)" : r.panelweight,
         namefe => isempty(r.fenames) ? "(none)" : fes
     ]
+    isempty(r.wgnames) || push!(info, namewg => wgs)
     return info
 end
 

--- a/src/slp.jl
+++ b/src/slp.jl
@@ -323,7 +323,7 @@ function _getcols!(est::SmoothLP, data, xnames)
 end
 
 function _makeYSr(dt, ss, horz; TF=Float64)
-    Y, X, CLU, W, T, esample, doffe = _makeYX(dt, horz)
+    Y, X, _, pt, CLU, W, T, esample, doffe = _makeYX(dt, horz)
     Tfull = size(dt.ys[1],1)
     ns = length(ss)
     # Filter valid rows within those filtered by _makeYX
@@ -482,9 +482,9 @@ function _select(est::SmoothLP{<:GridSearch{DirectSolve}}, y, C, crossy, crossC,
     return λs[iopt[est.criterion]], r, Sdiag
 end
 
-function _est(est::SmoothLP, data, xnames, ys, xs, ws, sts, fes, clus, pw, nlag,
+function _est(est::SmoothLP, data, xnames, ys, xs, ws, wgs, sts, fes, clus, pw, nlag,
         minhorz, nhorz, vce, subset, groups, iv, ix_iv, nendo, niv, yfs, xfs,
-        firststagebyhorz, testweakiv; TF=Float64)
+        firststagebyhorz, testweakiv, checkrows; TF=Float64)
     length(ys) > 1 && throw(ArgumentError("accept only one outcome variable"))
     vce isa ClusterCovariance && throw(ArgumentError(
         "cluster-robust VCE is not supported for smoothed local projection"))
@@ -497,7 +497,8 @@ function _est(est::SmoothLP, data, xnames, ys, xs, ws, sts, fes, clus, pw, nlag,
     firststagebyhorz = iv !== nothing && firststagebyhorz
     if !firststagebyhorz && !any(x->x isa Cum, view(xs, ix_nsm))
         xs_s = Any[xs[i] for i in ix_nsm]
-        dt = LPData(ys, xs_s, ws, sts, fes, clus, pw, nlag, minhorz, subset, groups, TF)
+        dt = LPData(ys, xs_s, ws, wgs, sts, fes, clus, pw, nlag, minhorz, subset, groups,
+            checkrows, TF)
     end
     F_kps = firststagebyhorz ? Vector{Float64}(undef, nhorz) : nothing
     p_kps = firststagebyhorz ? Vector{Float64}(undef, nhorz) : nothing
@@ -506,13 +507,16 @@ function _est(est::SmoothLP, data, xnames, ys, xs, ws, sts, fes, clus, pw, nlag,
          # Handle cases where all data need to be regenerated for each horizon
         if firststagebyhorz
             fitted, F_kps[i], p_kps[i] = _firststage(nendo, niv, yfs, xfs,
-                ws, sts, fes, clus, pw, nlag, h, subset, groups, testweakiv, vce; TF=TF)
+                ws, wgs, sts, fes, clus, pw, nlag, h, subset, groups, testweakiv, vce,
+                checkrows; TF=TF)
             xs[ix_iv] .= fitted
             xs_s = Any[xs[i] for i in ix_nsm]
-            dt = LPData(ys, xs_s, ws, sts, fes, clus, pw, nlag, h, subset, groups, TF)
+            dt = LPData(ys, xs_s, ws, wgs, sts, fes, clus, pw, nlag, h, subset, groups,
+                checkrows, TF)
         elseif any(x->x isa Cum, view(xs, ix_nsm))
             xs_s = Any[xs[i] for i in ix_nsm]
-            dt = LPData(ys, xs_s, ws, sts, fes, clus, pw, nlag, h, subset, groups, TF)
+            dt = LPData(ys, xs_s, ws, wgs, sts, fes, clus, pw, nlag, h, subset, groups,
+                checkrows, TF)
         end
         # xs could be changed by first-stage regression
         ss = view(xs, ix_sm)
@@ -591,7 +595,8 @@ function lp(r::LocalProjectionResult{<:SmoothLP}, vce::CovarianceEstimator)
     slpr = SmoothLPResult(s.θ, Σ, s.bm, s.λ, s.loocv, s.rss, s.gcv, s.aic,
         s.dof_fit, s.dof_res, s.search, s.m)
     return LocalProjectionResult(r.B, V, r.T, r.est, slpr, vce,
-        r.ynames, r.xnames, r.wnames, r.stnames, r.fenames, r.lookupy, r.lookupx, r.lookupw,
+        r.ynames, r.xnames, r.wnames, r.wgnames, r.stnames, r.fenames,
+        r.lookupy, r.lookupx, r.lookupw,
         r.panelid, r.panelweight, r.nlag, r.minhorz, r.subset,
         r.normnames, r.normtars, r.normmults,
         r.endonames, r.ivnames, r.firststagebyhorz, r.F_kp, r.p_kp, r.nocons)
@@ -643,7 +648,8 @@ function lp(r::LocalProjectionResult{<:SmoothLP}, λ::Real;
     slpr = SmoothLPResult(θ, Σ, bm, λ, loocv, rss, gcv, aic, dof_fit, dof_res,
         r.estres.search, m1)
     return LocalProjectionResult(B, V, r.T, r.est, slpr, vce1,
-        r.ynames, r.xnames, r.wnames, r.stnames, r.fenames, r.lookupy, r.lookupx, r.lookupw,
+        r.ynames, r.xnames, r.wnames, r.wgnames, r.stnames, r.fenames,
+        r.lookupy, r.lookupx, r.lookupw,
         r.panelid, r.panelweight, r.nlag, r.minhorz, r.subset,
         r.normnames, r.normtars, r.normmults,
         r.endonames, r.ivnames, r.firststagebyhorz, r.F_kp, r.p_kp, r.nocons)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -295,12 +295,35 @@ function _solve_residuals!(Y::AbstractVecOrMat, X::AbstractMatrix,
     return iterations, convergeds
 end
 
+function _solve_residuals!(X::AbstractVecOrMat,
+        feM::AbstractFixedEffectSolver; progress_bar=false, kwargs...)
+    iterations = Int[]
+    convergeds = Bool[]
+    for j in axes(X, 2)
+        _, iteration, converged = solve_residuals!(view(X,:,j), feM; kwargs...)
+        push!(iterations, iteration)
+        push!(convergeds, converged)
+    end
+    return iterations, convergeds
+end
+
 # Residualize columns in Y and X with weights W for fixed effects FE
 function _feresiduals!(Y::AbstractVecOrMat, X::AbstractMatrix, FE::Vector{FixedEffect},
         W::AbstractWeights; nfethreads::Int=Threads.nthreads(),
         fetol::Real=1e-8, femaxiter::Int=10000)
     feM = AbstractFixedEffectSolver{Float64}(FE, W, Val{:cpu}, nfethreads)
     iters, convs = _solve_residuals!(Y, X, feM;
+        tol=fetol, maxiter=femaxiter, progress_bar=false)
+    iter = maximum(iters)
+    conv = all(convs)
+    conv || @warn "no convergence of fixed effect solver in $(iter) iterations"
+end
+
+function _feresiduals!(X::AbstractVecOrMat, FE::Vector{FixedEffect},
+        W::AbstractWeights; nfethreads::Int=Threads.nthreads(),
+        fetol::Real=1e-8, femaxiter::Int=10000)
+    feM = AbstractFixedEffectSolver{Float64}(FE, W, Val{:cpu}, nfethreads)
+    iters, convs = _solve_residuals!(X, feM;
         tol=fetol, maxiter=femaxiter, progress_bar=false)
     iter = maximum(iters)
     conv = all(convs)

--- a/test/data.jl
+++ b/test/data.jl
@@ -3,10 +3,11 @@
     ys = Any[randn(T), randn(T)]
     xs = Any[randn(T), randn(T)]
     ws = ys
+    wgs = Any[]
     fes0 = Any[]
     clus0 = Any[]
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test T1 == T-8
     @test size(Y) == (T1, 2)
     @test size(X) == (T1, 8)
@@ -18,12 +19,16 @@
     @test X[:,8] == ws[2][1:end-8]
     @test all(eT)
     @test doffe == 0
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing, false)
+    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
+    @test Y1 == Y
+    @test X1 == X
 
     groups = [1:20, 21:T]
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 3, 0, nothing, groups)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, groups, true)
     @test dt.Xfull[:,1] == xs[1][vcat(4:20,24:T)]
     @test dt.Xfull[:,3] == ws[1][vcat(3:19,23:T-1)]
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test T1 == T-16
     @test size(Y) == (T1, 2)
     @test size(X) == (T1, 8)
@@ -34,10 +39,23 @@
     @test X[:,4] == ws[2][vcat(3:20-6,23:T-6)]
     @test X[:,8] == ws[2][vcat(1:20-8,21:T-8)]
     @test all(eT)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, groups, false)
+    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
+    @test Y1 == Y
+    @test X1 == X
+
+    groups1 = [1:50, 51:T]
+    wgs1 = Any[randn(T), randn(T)]
+    dt = LPData(ys, xs, ws, wgs1, nothing, fes0, clus0, nothing, 3, 0, nothing, groups1, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    dt1 = LPData(ys, xs, ws, wgs1, nothing, fes0, clus0, nothing, 3, 0, nothing, groups1, false)
+    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
+    @test Y1 == Y
+    @test X1 == X
 
     sts = Any[rand(T), rand(T)]
-    dt = LPData(ys, xs, ws, sts, fes0, clus0, nothing, 1, 0, nothing, nothing)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test size(X) == (99, 6)
     @test X[:,1] == xs[1][2:end]
     @test X[:,2] == xs[2][2:end]
@@ -46,12 +64,16 @@
     @test X[:,5] == ys[2][1:99].*sts[1][2:end]
     @test X[:,6] == ys[2][1:99].*sts[2][2:end]
     @test all(eT)
+    dt1 = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, nothing, false)
+    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 0)
+    @test Y1 == Y
+    @test X1 == X
 
     fes = Any[vcat(fill(1,20), fill(2,80))]
     clus = Any[vcat(fill(1,20), fill(2,80))]
-    dt = LPData(ys, xs, ws, nothing, fes, clus, nothing, 3, 0, nothing, groups)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes, clus, nothing, 3, 0, nothing, groups, true)
     @test dt.fes[1] == dt.clus[1]
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test T1 == T-16
     @test size(Y) == (T1, 2)
     @test size(X) == (T1, 8)
@@ -65,10 +87,16 @@
     @test X[13:T1,8] ≈ ws[2][21:T-8] .- sum(ws[2][21:T-8])./(T1-13+1) atol=1e-8
     @test all(eT)
     @test doffe == 1
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes, clus, nothing, 3, 0, nothing, groups, false)
+    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt1, 5)
+    @test Y1 == Y
+    @test X1 == X
+    @test CLU1 == CLU
+    @test doffe1 == doffe
 
     pw = vcat(fill(4,20), fill(1,80))
-    dt = LPData(ys, xs, ws, nothing, fes, clus0, pw, 3, 0, nothing, groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes, clus0, pw, 3, 0, nothing, groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test Y[1:12,1] ≈ 2.0.*(ys[1][9:20] .- sum(ys[1][9:20])./12) atol=1e-8
     @test Y[13:T1,1] ≈ ys[1][29:T] .- sum(ys[1][29:T])./(T1-13+1) atol=1e-8
     @test Y[1:12,2] ≈ 2.0.*(ys[2][9:20] .- sum(ys[2][9:20])./12) atol=1e-8
@@ -79,9 +107,16 @@
     @test X[13:T1,8] ≈ ws[2][21:T-8] .- sum(ws[2][21:T-8])./(T1-13+1) atol=1e-8
     @test all(eT)
     @test doffe == 2
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes, clus0, pw, 3, 0, nothing, groups, false)
+    Y1, X1, _, pt, CLU1, W1, T1, eT, doffe1 = _makeYX(dt1, 5)
+    @test Y1 == Y
+    @test X1 == X
+    @test CLU1 == CLU
+    @test W1 == W
+    @test doffe1 == doffe
 
-    dt = LPData(ys, xs, ws, sts, fes0, clus0, nothing, 1, 0, nothing, groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test size(X) == (98, 6)
     @test X[:,1] == xs[1][vcat(2:20,22:T)]
     @test X[:,2] == xs[2][vcat(2:20,22:T)]
@@ -90,33 +125,51 @@
     @test X[:,5] == ys[2][vcat(1:19,21:T-1)].*sts[1][vcat(2:20,22:T)]
     @test X[:,6] == ys[2][vcat(1:19,21:T-1)].*sts[2][vcat(2:20,22:T)]
     @test all(eT)
+    dt1 = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, groups, false)
+    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
+    @test Y1 == Y
+    @test X1 == X
+    @test CLU1 == CLU
+    @test doffe1 == doffe
 
     ys = Any[randn(T)]
     xs = Any[]
     ws = ys
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 99
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 1)
     @test Y == reshape(ys[1][2:end], T1, 1)
     @test X == reshape(ws[1][1:end-1], T1, 1)
     @test all(eT)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, false)
+    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
+    @test Y1 == Y
+    @test X1 == X
+    @test CLU1 == CLU
+    @test doffe1 == doffe
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 98
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 1)
     @test Y == reshape(ys[1][vcat(2:20,22:T)], T1, 1)
     @test X == reshape(ws[1][vcat(1:19,21:T-1)], T1, 1)
     @test all(eT)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, groups, false)
+    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
+    @test Y1 == Y
+    @test X1 == X
+    @test CLU1 == CLU
+    @test doffe1 == doffe
 
     ys[1][2], ys[1][3] = NaN, Inf
     xs = Any[convert(Vector{Union{Float64, Missing}}, randn(T))]
     xs[1][3] = missing
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 96
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -125,8 +178,8 @@
     @test X[:,2] == ws[1][4:end-1]
     @test eT == ((1:99).>3)
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 95
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -135,8 +188,8 @@
     @test X[:,2] == ws[1][vcat(4:19,21:T-1)]
     @test eT == ((1:98).>3)
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 1, (1:100).<=90, nothing)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 1, (1:100).<=90, nothing, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 85
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -146,8 +199,8 @@
     # eT covers 2:99 in full data
     @test eT == ((1:98).>3) .& ((1:98).<=88)
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 1, (1:100).<=90, groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 1, (1:100).<=90, groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -156,33 +209,37 @@
     @test X[:,2] == ws[1][vcat(4:18,21:88)]
     @test eT == ((1:96).>3) .& ((1:96).<=86)
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, ((1:100).<60).|((1:100).>=70), nothing)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+        ((1:100).<60).|((1:100).>=70), nothing, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test Y[:] == ys[1][vcat(6:59,72:T)]
     @test X[:,1] == xs[1][vcat(5:58,71:T-1)]
     @test X[:,2] == ws[1][vcat(4:57,70:T-2)]
     @test eT == ((1:98).>3) .& (((1:98).<58) .| ((1:98).>=70))
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, ((1:100).<60).|((1:100).>=70), groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+        ((1:100).<60).|((1:100).>=70), groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 81
     @test Y[:] == ys[1][vcat(6:20,23:59,72:T)]
     @test X[:,1] == xs[1][vcat(5:19,22:58,71:T-1)]
     @test X[:,2] == ws[1][vcat(4:18,21:57,70:T-2)]
     @test eT == ((1:96).>3) .& (((1:96).<56) .| ((1:96).>=68))
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, ((1:100).<16).|((1:100).>=26), groups)
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+        ((1:100).<16).|((1:100).>=26), groups, true)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test Y[:] == ys[1][vcat(6:15,28:T)]
     @test X[:,1] == xs[1][vcat(5:14,27:T-1)]
     @test X[:,2] == ws[1][vcat(4:13,26:T-2)]
     @test eT == ((1:96).>3) .& (((1:96).<14) .| ((1:96).>=24))
 
-    dt = LPData(ys, xs, ws, nothing, fes, clus, pw, 1, 0, ((1:100).<16).|((1:100).>=26), groups)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes, clus, pw, 1, 0,
+        ((1:100).<16).|((1:100).>=26), groups, true)
     @test dt.fes[1] == dt.clus[1]
-    Y, X, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test Y[1:10,1] ≈ 2.0.*(ys[1][6:15] .- sum(ys[1][6:15])./10) atol=1e-8
     @test Y[11:T1,1] ≈ ys[1][28:T] .- sum(ys[1][28:T])./(T1-10) atol=1e-8
@@ -192,16 +249,20 @@
     @test X[11:T1,2] ≈ ws[1][26:T-2] .- sum(ws[1][26:T-2])./(T1-10) atol=1e-8
     @test doffe == 1
 
-    @test_throws ArgumentError LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 0, 0, nothing, nothing)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 0, 0,
+        nothing, nothing, true)
     ys = Any[]
-    @test_throws ArgumentError LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+        nothing, nothing, true)
     ws = Any[]
-    @test_throws ArgumentError LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+        nothing, nothing, true)
 
     ys = Any[[Inf, NaN, 1.0]]
     xs = Any[]
     ws = ys
-    @test_throws ArgumentError LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+        nothing, nothing, true)
 
     @test sprint(show, dt) == "Data for local projection"
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -6,8 +6,9 @@
     wgs = Any[]
     fes0 = Any[]
     clus0 = Any[]
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 3, 0, nothing,
+        nothing, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test T1 == T-8
     @test size(Y) == (T1, 2)
     @test size(X) == (T1, 8)
@@ -19,16 +20,18 @@
     @test X[:,8] == ws[2][1:end-8]
     @test all(eT)
     @test doffe == 0
-    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing, false)
-    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 3, 0,
+        nothing, nothing, false)
+    Y1, X1, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
     @test Y1 == Y
     @test X1 == X
 
     groups = [1:20, 21:T]
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, groups, true)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 3, 0,
+        nothing, groups, true)
     @test dt.Xfull[:,1] == xs[1][vcat(4:20,24:T)]
     @test dt.Xfull[:,3] == ws[1][vcat(3:19,23:T-1)]
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test T1 == T-16
     @test size(Y) == (T1, 2)
     @test size(X) == (T1, 8)
@@ -39,23 +42,27 @@
     @test X[:,4] == ws[2][vcat(3:20-6,23:T-6)]
     @test X[:,8] == ws[2][vcat(1:20-8,21:T-8)]
     @test all(eT)
-    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, groups, false)
-    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 3, 0, nothing,
+        groups, false)
+    Y1, X1, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
     @test Y1 == Y
     @test X1 == X
 
     groups1 = [1:50, 51:T]
     wgs1 = Any[randn(T), randn(T)]
-    dt = LPData(ys, xs, ws, wgs1, nothing, fes0, clus0, nothing, 3, 0, nothing, groups1, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
-    dt1 = LPData(ys, xs, ws, wgs1, nothing, fes0, clus0, nothing, 3, 0, nothing, groups1, false)
-    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
+    dt = LPData(ys, xs, ws, wgs1, nothing, fes0, nothing, clus0, nothing, 3, 0,
+        nothing, groups1, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    dt1 = LPData(ys, xs, ws, wgs1, nothing, fes0, nothing, clus0, nothing, 3, 0,
+        nothing, groups1, false)
+    Y1, X1, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt1, 5)
     @test Y1 == Y
     @test X1 == X
 
     sts = Any[rand(T), rand(T)]
-    dt = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, sts, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test size(X) == (99, 6)
     @test X[:,1] == xs[1][2:end]
     @test X[:,2] == xs[2][2:end]
@@ -64,16 +71,18 @@
     @test X[:,5] == ys[2][1:99].*sts[1][2:end]
     @test X[:,6] == ys[2][1:99].*sts[2][2:end]
     @test all(eT)
-    dt1 = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, nothing, false)
-    Y1, X1, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt1, 0)
+    dt1 = LPData(ys, xs, ws, wgs, sts, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, false)
+    Y1, X1, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt1, 0)
     @test Y1 == Y
     @test X1 == X
 
     fes = Any[vcat(fill(1,20), fill(2,80))]
     clus = Any[vcat(fill(1,20), fill(2,80))]
-    dt = LPData(ys, xs, ws, wgs, nothing, fes, clus, nothing, 3, 0, nothing, groups, true)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes, nothing, clus, nothing, 3, 0,
+        nothing, groups, true)
     @test dt.fes[1] == dt.clus[1]
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test T1 == T-16
     @test size(Y) == (T1, 2)
     @test size(X) == (T1, 8)
@@ -87,16 +96,18 @@
     @test X[13:T1,8] ≈ ws[2][21:T-8] .- sum(ws[2][21:T-8])./(T1-13+1) atol=1e-8
     @test all(eT)
     @test doffe == 1
-    dt1 = LPData(ys, xs, ws, wgs, nothing, fes, clus, nothing, 3, 0, nothing, groups, false)
-    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt1, 5)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes, nothing, clus, nothing, 3, 0,
+        nothing, groups, false)
+    Y1, X1, _, pt, FE, CLU1, W, T1, eT, doffe1 = _makeYX(dt1, 5)
     @test Y1 == Y
     @test X1 == X
     @test CLU1 == CLU
     @test doffe1 == doffe
 
     pw = vcat(fill(4,20), fill(1,80))
-    dt = LPData(ys, xs, ws, wgs, nothing, fes, clus0, pw, 3, 0, nothing, groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes, nothing, clus0, pw, 3, 0, nothing,
+        groups, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 5)
     @test Y[1:12,1] ≈ 2.0.*(ys[1][9:20] .- sum(ys[1][9:20])./12) atol=1e-8
     @test Y[13:T1,1] ≈ ys[1][29:T] .- sum(ys[1][29:T])./(T1-13+1) atol=1e-8
     @test Y[1:12,2] ≈ 2.0.*(ys[2][9:20] .- sum(ys[2][9:20])./12) atol=1e-8
@@ -107,16 +118,18 @@
     @test X[13:T1,8] ≈ ws[2][21:T-8] .- sum(ws[2][21:T-8])./(T1-13+1) atol=1e-8
     @test all(eT)
     @test doffe == 2
-    dt1 = LPData(ys, xs, ws, wgs, nothing, fes, clus0, pw, 3, 0, nothing, groups, false)
-    Y1, X1, _, pt, CLU1, W1, T1, eT, doffe1 = _makeYX(dt1, 5)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes, nothing, clus0, pw, 3, 0, nothing,
+        groups, false)
+    Y1, X1, _, pt, FE, CLU1, W1, T1, eT, doffe1 = _makeYX(dt1, 5)
     @test Y1 == Y
     @test X1 == X
     @test CLU1 == CLU
     @test W1 == W
     @test doffe1 == doffe
 
-    dt = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, sts, fes0, nothing, clus0, nothing, 1, 0, nothing,
+        groups, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test size(X) == (98, 6)
     @test X[:,1] == xs[1][vcat(2:20,22:T)]
     @test X[:,2] == xs[2][vcat(2:20,22:T)]
@@ -125,8 +138,9 @@
     @test X[:,5] == ys[2][vcat(1:19,21:T-1)].*sts[1][vcat(2:20,22:T)]
     @test X[:,6] == ys[2][vcat(1:19,21:T-1)].*sts[2][vcat(2:20,22:T)]
     @test all(eT)
-    dt1 = LPData(ys, xs, ws, wgs, sts, fes0, clus0, nothing, 1, 0, nothing, groups, false)
-    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
+    dt1 = LPData(ys, xs, ws, wgs, sts, fes0, nothing, clus0, nothing, 1, 0, nothing,
+        groups, false)
+    Y1, X1, _, pt, FE, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
     @test Y1 == Y
     @test X1 == X
     @test CLU1 == CLU
@@ -135,31 +149,35 @@
     ys = Any[randn(T)]
     xs = Any[]
     ws = ys
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 99
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 1)
     @test Y == reshape(ys[1][2:end], T1, 1)
     @test X == reshape(ws[1][1:end-1], T1, 1)
     @test all(eT)
-    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, false)
-    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, false)
+    Y1, X1, _, pt, FE, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
     @test Y1 == Y
     @test X1 == X
     @test CLU1 == CLU
     @test doffe1 == doffe
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, groups, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 98
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 1)
     @test Y == reshape(ys[1][vcat(2:20,22:T)], T1, 1)
     @test X == reshape(ws[1][vcat(1:19,21:T-1)], T1, 1)
     @test all(eT)
-    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, groups, false)
-    Y1, X1, _, pt, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
+    dt1 = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, groups, false)
+    Y1, X1, _, pt, FE, CLU1, W, T1, eT, doffe1 = _makeYX(dt, 0)
     @test Y1 == Y
     @test X1 == X
     @test CLU1 == CLU
@@ -168,8 +186,9 @@
     ys[1][2], ys[1][3] = NaN, Inf
     xs = Any[convert(Vector{Union{Float64, Missing}}, randn(T))]
     xs[1][3] = missing
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 96
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -178,8 +197,9 @@
     @test X[:,2] == ws[1][4:end-1]
     @test eT == ((1:99).>3)
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, groups, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 0)
     @test T1 == 95
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -188,8 +208,9 @@
     @test X[:,2] == ws[1][vcat(4:19,21:T-1)]
     @test eT == ((1:98).>3)
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 1, (1:100).<=90, nothing, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 1,
+        (1:100).<=90, nothing, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 85
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -199,8 +220,9 @@
     # eT covers 2:99 in full data
     @test eT == ((1:98).>3) .& ((1:98).<=88)
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 1, (1:100).<=90, groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 1,
+        (1:100).<=90, groups, true)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test size(Y) == (T1, 1)
     @test size(X) == (T1, 2)
@@ -209,37 +231,37 @@
     @test X[:,2] == ws[1][vcat(4:18,21:88)]
     @test eT == ((1:96).>3) .& ((1:96).<=86)
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
         ((1:100).<60).|((1:100).>=70), nothing, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test Y[:] == ys[1][vcat(6:59,72:T)]
     @test X[:,1] == xs[1][vcat(5:58,71:T-1)]
     @test X[:,2] == ws[1][vcat(4:57,70:T-2)]
     @test eT == ((1:98).>3) .& (((1:98).<58) .| ((1:98).>=70))
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
         ((1:100).<60).|((1:100).>=70), groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 81
     @test Y[:] == ys[1][vcat(6:20,23:59,72:T)]
     @test X[:,1] == xs[1][vcat(5:19,22:58,71:T-1)]
     @test X[:,2] == ws[1][vcat(4:18,21:57,70:T-2)]
     @test eT == ((1:96).>3) .& (((1:96).<56) .| ((1:96).>=68))
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
         ((1:100).<16).|((1:100).>=26), groups, true)
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test Y[:] == ys[1][vcat(6:15,28:T)]
     @test X[:,1] == xs[1][vcat(5:14,27:T-1)]
     @test X[:,2] == ws[1][vcat(4:13,26:T-2)]
     @test eT == ((1:96).>3) .& (((1:96).<14) .| ((1:96).>=24))
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes, clus, pw, 1, 0,
+    dt = LPData(ys, xs, ws, wgs, nothing, fes, nothing, clus, pw, 1, 0,
         ((1:100).<16).|((1:100).>=26), groups, true)
     @test dt.fes[1] == dt.clus[1]
-    Y, X, _, pt, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
+    Y, X, _, pt, FE, CLU, W, T1, eT, doffe = _makeYX(dt, 1)
     @test T1 == 83
     @test Y[1:10,1] ≈ 2.0.*(ys[1][6:15] .- sum(ys[1][6:15])./10) atol=1e-8
     @test Y[11:T1,1] ≈ ys[1][28:T] .- sum(ys[1][28:T])./(T1-10) atol=1e-8
@@ -249,20 +271,20 @@
     @test X[11:T1,2] ≈ ws[1][26:T-2] .- sum(ws[1][26:T-2])./(T1-10) atol=1e-8
     @test doffe == 1
 
-    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 0, 0,
-        nothing, nothing, true)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0,
+        nothing, 0, 0, nothing, nothing, true)
     ys = Any[]
-    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
-        nothing, nothing, true)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0,
+        nothing, 1, 0, nothing, nothing, true)
     ws = Any[]
-    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
-        nothing, nothing, true)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0,
+        nothing, 1, 0, nothing, nothing, true)
 
     ys = Any[[Inf, NaN, 1.0]]
     xs = Any[]
     ws = ys
-    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0,
-        nothing, nothing, true)
+    @test_throws ArgumentError LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0,
+        nothing, 1, 0, nothing, nothing, true)
 
     @test sprint(show, dt) == "Data for local projection"
 end

--- a/test/lp.jl
+++ b/test/lp.jl
@@ -143,7 +143,7 @@ end
     # Have one fewer coefficient because the constant term is replace by FE
     @test r1.B ≈ r.B[2:61,:,:]
     # Does not seem to be an issue but ≈ fails for certain horizons
-    @test maximum(abs.(r1.V[:,:,:] .- r.V[2:61,2:61,:])) < 5e-8
+    @test maximum(abs.(r1.V[:,:,:] .- r.V[2:61,2:61,:])) < 1e-7
     # V is not exactly the same because of the removed intercept
     @test r1.T ≈ r.T
     @test r1.fenames == [:gid]

--- a/test/lp.jl
+++ b/test/lp.jl
@@ -29,7 +29,7 @@ end
 @testset "LocalProjectionResult" begin
     B = cat(randn(5,2,1), randn(5,2,1); dims=3)
     V = cat(randn(10,10), randn(10,10); dims=3)
-    r = LocalProjectionResult(B, V, [1,2], LeastSquaresLP(), nothing, HRVCE(), VarName[:y1, :y2], VarName[:x], VarName[:w1, :w2], VarName[], VarName[], Dict{VarName,Int}(:y1=>1, :y2=>2), Dict{VarName,Int}(:x=>1), Dict{VarName,Int}(:w1=>1,:w2=>2,:y1=>3,:y2=>4), nothing, nothing, 2, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
+    r = LocalProjectionResult(B, V, [1,2], LeastSquaresLP(), nothing, HRVCE(), VarName[:y1, :y2], VarName[:x], VarName[:w1, :w2], VarName[], VarName[], VarName[], Dict{VarName,Int}(:y1=>1, :y2=>2), Dict{VarName,Int}(:x=>1), Dict{VarName,Int}(:w1=>1,:w2=>2,:y1=>3,:y2=>4), nothing, nothing, 2, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
     @test coef(r, 1, :x) == B[1,1,1]
     @test coef(r, 2, :w1, yname=:y2, lag=1) == B[2,2,2]
     @test coef(r, 2, :w1, lag=2) == B[4,1,2]
@@ -48,7 +48,7 @@ end
         Outcome variables:              y1 y2    Minimum horizon:                    0
         Regressor:                          x    Lagged controls:                w1 w2
         ──────────────────────────────────────────────────────────────────────────────"""
-    r = LocalProjectionResult(ones(1,1,1), ones(1,1,1), [1], LeastSquaresLP(), nothing, HRVCE(), VarName[:y], VarName[], VarName[:w], VarName[], VarName[], Dict{VarName,Int}(:y=>1), Dict{VarName,Int}(), Dict{VarName,Int}(:w=>1), nothing, nothing, 1, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
+    r = LocalProjectionResult(ones(1,1,1), ones(1,1,1), [1], LeastSquaresLP(), nothing, HRVCE(), VarName[:y], VarName[], VarName[:w], VarName[], VarName[], VarName[], Dict{VarName,Int}(:y=>1), Dict{VarName,Int}(), Dict{VarName,Int}(:w=>1), nothing, nothing, 1, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
     @test sprint(show, MIME("text/plain"), r) == """
         LocalProjectionResult with 1 lag over 1 horizon:
         ──────────────────────────────────────────────────────────────────────────────
@@ -57,7 +57,7 @@ end
         Outcome variable:                   y    Minimum horizon:                    0
         Regressor:                               Lagged control:                     w
         ──────────────────────────────────────────────────────────────────────────────"""
-    r = LocalProjectionResult(ones(1,1,1), ones(1,1,1), [1], LeastSquaresLP(), nothing, HRVCE(), VarName[Cum(:y)], VarName[Cum(:x)], VarName[:w], VarName[:rec, :exp], VarName[], Dict{VarName,Int}(Cum(:y)=>1), Dict{VarName,Int}(Cum(:x)=>1), Dict{VarName,Int}(:w=>1), :pid, nothing, 1, 0, nothing, nothing, nothing, nothing, VarName[Cum(:x)], VarName[:z1,:z2], false, [0.12345678], 0.22345678, true)
+    r = LocalProjectionResult(ones(1,1,1), ones(1,1,1), [1], LeastSquaresLP(), nothing, HRVCE(), VarName[Cum(:y)], VarName[Cum(:x)], VarName[:w], VarName[], VarName[:rec, :exp], VarName[], Dict{VarName,Int}(Cum(:y)=>1), Dict{VarName,Int}(Cum(:x)=>1), Dict{VarName,Int}(:w=>1), :pid, nothing, 1, 0, nothing, nothing, nothing, nothing, VarName[Cum(:x)], VarName[:z1,:z2], false, [0.12345678], 0.22345678, true)
     @test sprint(show, MIME("text/plain"), r) == """
         LocalProjectionResult with 1 lag over 1 horizon:
         ──────────────────────────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ end
         Fixed effects:                 (none)    
         ──────────────────────────────────────────────────────────────────────────────"""
 
-    r = LocalProjectionResult(B, V, [1,2], LeastSquaresLP(), nothing, HRVCE(), VarName[:y1, :y2], VarName[:x], VarName[:w1, :w2], VarName[], VarName[:fe1], Dict{VarName,Int}(:y1=>1, :y2=>2), Dict{VarName,Int}(:x=>1), Dict{VarName,Int}(:w1=>1,:w2=>2,:y1=>3,:y2=>4), :pid, :wt, 2, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
+    r = LocalProjectionResult(B, V, [1,2], LeastSquaresLP(), nothing, HRVCE(), VarName[:y1, :y2], VarName[:x], VarName[:w1, :w2], VarName[], VarName[], VarName[:fe1], Dict{VarName,Int}(:y1=>1, :y2=>2), Dict{VarName,Int}(:x=>1), Dict{VarName,Int}(:w1=>1,:w2=>2,:y1=>3,:y2=>4), :pid, :wt, 2, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
     @test sprint(show, MIME("text/plain"), r) == """
         LocalProjectionResult with 2 lags over 2 horizons:
         ──────────────────────────────────────────────────────────────────────────────
@@ -88,6 +88,20 @@ end
         Unit ID:                          pid    Weights:                           wt
         Fixed effects:                    fe1    
         ──────────────────────────────────────────────────────────────────────────────"""
+    r = LocalProjectionResult(B, V, [1,2], LeastSquaresLP(), nothing, HRVCE(), VarName[:y1, :y2], VarName[:x], VarName[:w1, :w2], VarName[:wg1], VarName[], VarName[:fe1], Dict{VarName,Int}(:y1=>1, :y2=>2), Dict{VarName,Int}(:x=>1), Dict{VarName,Int}(:w1=>1,:w2=>2,:y1=>3,:y2=>4), :pid, :wt, 2, 0, nothing, nothing, nothing, nothing, nothing, nothing, false, nothing, nothing, true)
+    @test sprint(show, MIME("text/plain"), r) == """
+        LocalProjectionResult with 2 lags over 2 horizons:
+        ──────────────────────────────────────────────────────────────────────────────
+        Variable Specifications
+        ──────────────────────────────────────────────────────────────────────────────
+        Outcome variables:              y1 y2    Minimum horizon:                    0
+        Regressor:                          x    Lagged controls:            w1 w2 wg1
+        ──────────────────────────────────────────────────────────────────────────────
+        Panel Specifications
+        ──────────────────────────────────────────────────────────────────────────────
+        Unit ID:                          pid    Weights:                           wt
+        Fixed effects:                    fe1    Interacted Lagged control:        wg1
+        ──────────────────────────────────────────────────────────────────────────────"""
 end
 
 @testset "lp" begin
@@ -95,7 +109,7 @@ end
     ys = Any[randn(T), randn(T)]
     xs = Any[randn(T), randn(T)]
     ws = ys
-    dt = LPData(ys, xs, ws, nothing, Any[], Any[], nothing, 3, 0, nothing, nothing)
+    dt = LPData(ys, xs, ws, Any[], nothing, Any[], Any[], nothing, 3, 0, nothing, nothing, true)
     b, v, t, m = _lp(dt, 5, SimpleVCE(), nothing, nothing)
     @test size(b) == (8, 2)
     @test size(v) == (16, 16)
@@ -133,6 +147,17 @@ end
     @test r1.fenames == [:gid]
     @test r1.panelid == :gid
 
+    dfc = df[!,[ns..., :gid, :wt]]
+    dfc = dfc[completecases(dfc), :]
+    rc = lp(dfc, :ebp, wnames=ns, nlag=12, nhorz=48, vce=HRVCE())
+    rc1 = lp(dfc, :ebp, wnames=ns, nlag=12, nhorz=48, vce=HRVCE(), checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
+    rc = lp(dfc, :ebp, wnames=ns, nlag=12, nhorz=48, panelid=:gid, panelweight=:wt, vce=HRVCE())
+    rc1 = lp(dfc, :ebp, wnames=ns, nlag=12, nhorz=48, panelid=:gid, panelweight=:wt, vce=HRVCE(), checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
+
     f = irf(r, :ebp, :ff4_tc, lag=1)
     @test coef(f)[1] ≈ 0.394494467439933 atol=1e-8
     @test coef(f)[20] ≈ -0.552849402428304 atol=1e-8
@@ -160,6 +185,21 @@ end
     @test rn.normmults ≈ [-5.3028242533068495] atol=1e-8
     @test riv.endonames == VarName[:ff]
     @test riv.ivnames == VarName[:ff4_tc]
+
+    rnc = lp(dfc, :ebp, xnames=:ff4_tc, wnames=(:ff4_tc,), nlag=12, nhorz=2,
+        normalize=:ff4_tc=>:ff, vce=HRVCE())
+    rivc = lp(dfc, :ebp, xnames=:ff, wnames=(:ff4_tc,), nlag=12, nhorz=2,
+        iv=:ff=>:ff4_tc, vce=HRVCE())
+    rnc1 = lp(dfc, :ebp, xnames=:ff4_tc, wnames=(:ff4_tc,), nlag=12, nhorz=2,
+        normalize=:ff4_tc=>:ff, vce=HRVCE(), checkrows=false)
+    rivc1 = lp(dfc, :ebp, xnames=:ff, wnames=(:ff4_tc,), nlag=12, nhorz=2,
+        iv=:ff=>:ff4_tc, vce=HRVCE(), checkrows=false)
+    @test rnc1.B ≈ rnc.B
+    @test rnc1.V ≈ rnc.V
+    @test rivc1.B ≈ rivc.B
+    @test rivc1.V ≈ rivc.V
+    @test rivc1.F_kp ≈ rivc.F_kp
+    @test rivc1.p_kp ≈ rivc.p_kp
 
     # Construct lags for comparing results with FixedEffectModels.jl
     for var in (:ebp, :ff4_tc)
@@ -252,6 +292,16 @@ end
     @test r1_0.F_kp[1] ≈ rfe.F_kp atol=1e-8
     @test r1_0.p_kp[1] ≈ rfe.p_kp atol=1e-8
 
+    dfc = df[!,[:y, :g, :newsy, :exp, :rec, :recnewsy, :expnewsy, :recg, :expg]]
+    dfc = dfc[completecases(dfc), :]
+    rc = lp(dfc, Cum(:y), xnames=Cum(:g), wnames=(:newsy, :y, :g), iv=Cum(:g)=>:newsy,
+        nlag=4, nhorz=17, addylag=false, firststagebyhorz=true, vce=HARVCE(EWC()))
+    rc1 = lp(dfc, Cum(:y), xnames=Cum(:g), wnames=(:newsy, :y, :g), iv=Cum(:g)=>:newsy,
+        nlag=4, nhorz=17, addylag=false, firststagebyhorz=true, vce=HARVCE(EWC()),
+        checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
+
     r2 = lp(df, Cum(:y), xnames=Cum(:g), wnames=(:newsy, :y, :g), iv=Cum(:g)=>(:newsy, :g),
         nlag=4, nhorz=16, minhorz=1, addylag=false, firststagebyhorz=true, vce=HARVCE(EWC()))
     f2 = irf(r2, Cum(:y), Cum(:g))
@@ -262,6 +312,14 @@ end
     @test stderror(f2)[1] ≈ 0.15265027120755809 atol=1e-8
     @test stderror(f2)[8] ≈ 0.0813792791970263 atol=1e-8
     @test stderror(f2)[16] ≈ 0.08518024610628232 atol=1e-8
+
+    rc = lp(dfc, Cum(:y), xnames=Cum(:g), wnames=(:newsy, :y, :g), iv=Cum(:g)=>(:newsy, :g),
+        nlag=4, nhorz=16, minhorz=1, addylag=false, firststagebyhorz=true, vce=HARVCE(EWC()))
+    rc1 = lp(dfc, Cum(:y), xnames=Cum(:g), wnames=(:newsy, :y, :g), iv=Cum(:g)=>(:newsy, :g),
+        nlag=4, nhorz=16, minhorz=1, addylag=false, firststagebyhorz=true, vce=HARVCE(EWC()),
+        checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
 
     # Omit WWII
     r1 = lp(df, Cum(:y), xnames=Cum(:g), wnames=(:newsy, :y, :g), iv=Cum(:g)=>:newsy,
@@ -292,7 +350,8 @@ end
     # nomit
     r2 = lp(df, Cum(:y), xnames=(Cum(:g,:rec), Cum(:g,:exp), :rec), wnames=(:newsy, :y, :g),
         iv=(Cum(:g,:rec), Cum(:g,:exp))=>(:recnewsy, :expnewsy, :recg, :expg),
-        states=(:rec, :exp), nlag=4, nhorz=16, minhorz=1, addylag=false, firststagebyhorz=true)
+        states=(:rec, :exp), nlag=4, nhorz=16, minhorz=1, addylag=false,
+        firststagebyhorz=true)
     f2rec = irf(r2, Cum(:y), Cum(:g,:rec))
     @test coef(f2rec)[1] ≈ .2718093668839 atol=1e-9
     @test coef(f2rec)[8] ≈ .6357587189621 atol=1e-9
@@ -301,6 +360,17 @@ end
     @test coef(f2exp)[1] ≈ .2660710337235 atol=1e-9
     @test coef(f2exp)[8] ≈ .3511868388287 atol=1e-9
     @test coef(f2exp)[16] ≈ .373442191223 atol=1e-9
+
+    rc = lp(dfc, Cum(:y), xnames=(Cum(:g,:rec), Cum(:g,:exp), :rec), wnames=(:newsy, :y, :g),
+        iv=(Cum(:g,:rec), Cum(:g,:exp))=>(:recnewsy, :expnewsy, :recg, :expg),
+        states=(:rec, :exp), nlag=4, nhorz=16, minhorz=1, addylag=false,
+        firststagebyhorz=true)
+    rc1 = lp(dfc, Cum(:y), xnames=(Cum(:g,:rec), Cum(:g,:exp), :rec), wnames=(:newsy, :y, :g),
+        iv=(Cum(:g,:rec), Cum(:g,:exp))=>(:recnewsy, :expnewsy, :recg, :expg),
+        states=(:rec, :exp), nlag=4, nhorz=16, minhorz=1, addylag=false,
+        firststagebyhorz=true, checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
 
     # wwii
     r2 = lp(df, Cum(:y), xnames=(Cum(:g,:rec), Cum(:g,:exp), :rec), wnames=(:newsy, :y, :g),
@@ -350,6 +420,12 @@ end
     @test f.B[2] ≈ -0.1599185 atol=1e-7
     @test f.B[4] ≈ -0.0047023 atol=1e-7
 
+    dfc = df[completecases(df), :]
+    rc = lp(dfc, :dlgrgdp, wnames=ws, nlag=3, nhorz=5, panelid=:iso)
+    rc1 = lp(dfc, :dlgrgdp, wnames=ws, nlag=3, nhorz=5, panelid=:iso, checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
+
     r1 = lp(df, :dlgrgdp, wnames=ws, nlag=3, nhorz=1, panelid=:iso, vce=cluster(:iso))
     f1 = irf(r1, :dlgrgdp, :dlgrgdp, lag=1)
     # Construct lags for comparing confidence intervals with FixedEffectModels.jl
@@ -372,6 +448,12 @@ end
     @test f1ci[1][1] ≈ confint(rfe)[1,1] atol=1e-8
     @test f1ci[2][1] ≈ confint(rfe)[1,2] atol=1e-8
 
+    rc = lp(dfc, :dlgrgdp, wnames=ws, nlag=3, nhorz=1, panelid=:iso, vce=cluster(:iso))
+    rc1 = lp(dfc, :dlgrgdp, wnames=ws, nlag=3, nhorz=1, panelid=:iso, vce=cluster(:iso),
+        checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
+
     # Must fill in the missing values at the end even they are not used
     # This avoids reg from dropping additional rows at the end in the first-stage regression
     f = x->lag(x, -2, default=1.0)
@@ -384,13 +466,56 @@ end
     f2 = irf(r2, :f2dlgrgdp, :dlgrgdp)
     @test coef(r2, 1, :dlgrgdp) ≈ coef(rfe)[end] atol=1e-8
     @test stderror(f2)[1] ≈ stderror(rfe)[end] atol=1e-8
-    @test r2.F_kp[1] ≈ rfe.F_kp atol=1e-8
-    @test r2.p_kp[1] ≈ rfe.p_kp atol=1e-8
+    @test r2.F_kp ≈ rfe.F_kp atol=1e-8
+    @test r2.p_kp ≈ rfe.p_kp atol=1e-8
     @test dof_residual(r2)[1] == 2409
+
+    dfc = df[completecases(df), :]
+    rc = lp(dfc, :f2dlgrgdp, xnames=:dlgrgdp, wnames=ws, nlag=3, nhorz=1,
+        iv=:dlgrgdp=>:dlgcpi, panelid=:iso, vce=cluster(:iso), addylag=false)
+    rc1 = lp(dfc, :f2dlgrgdp, xnames=:dlgrgdp, wnames=ws, nlag=3, nhorz=1,
+        iv=:dlgrgdp=>:dlgcpi, panelid=:iso, vce=cluster(:iso), addylag=false,
+        checkrows=false)
+    @test rc1.B ≈ rc.B
+    @test rc1.V ≈ rc.V
+
+    # Find the 7 countries without missing data for a balanced panel
+    # Verify that with wgs, results are the same as having full interactive columns
+    cc = combine(groupby(dfc,:iso), nrow=>:count)
+    dfb = dfc[dfc.iso.∈(cc[cc.count.==maximum(cc.count),:iso],),:]
+    sort!(dfb, [:iso, :year])
+    wgs = ntuple(l->Symbol(:l,l,:dlgrgdp), 3)
+    rhs = (term(:dlgrgdp)~term(:dlgcpi), term.(lws[4:end])...,
+        term.(wgs).&term(:iso)..., fe(:iso))
+    rfe = reg(dfb, term(:f2dlgrgdp)~rhs, cluster(:iso), subset=dfb.year.>1876)
+    r3 = lp(dfb, :f2dlgrgdp, xnames=:dlgrgdp, wnames=ws[2:3], wgnames=ws[1], nlag=3, nhorz=1,
+        iv=:dlgrgdp=>:dlgcpi, panelid=:iso, vce=cluster(:iso), addylag=false,
+        checkrows=false, balancedpanel=true)
+    f3 = irf(r3, :f2dlgrgdp, :dlgrgdp)
+    @test coef(r3, 1, :dlgrgdp) ≈ coef(rfe)[end] atol=1e-8
+    @test stderror(f3)[1] ≈ stderror(rfe)[end] atol=1e-8
+    @test r3.F_kp ≈ rfe.F_kp atol=1e-8
+    @test r3.p_kp ≈ rfe.p_kp atol=1e-8
+    @test dof_residual(r3)[1] == 979
 
     r = lp(df, :dlgrgdp, wnames=ws, nlag=3, nhorz=5, panelid=:iso, addpanelidfe=false)
     @test isempty(r.fenames)
 
+    # No redundant ylag with y in wgnames
+    # Also no constant added to wnames with nonempty wgnames
+    r = lp(dfb, :f2dlgrgdp, wnames=ws, wgnames=:f2dlgrgdp, nlag=3, nhorz=1,
+        panelid=:iso, addpanelidfe=false, checkrows=false, balancedpanel=true)
+    @test r.wnames == collect(ws)
+    @test isempty(r.fenames)
+
     @test_throws ArgumentError lp(df, :dlgrgdp, wnames=ws, fes=(:iso,))
     @test_throws ArgumentError lp(df, :dlgrgdp, wnames=ws, vce=cluster(:iso))
+    @test_throws ArgumentError lp(dfb, :f2dlgrgdp, xnames=:dlgrgdp, wnames=ws[2:3],
+        wgnames=ws[1], nlag=3, nhorz=1, iv=:dlgrgdp=>:dlgcpi, panelid=:iso,
+        vce=cluster(:iso), addylag=false)
+    @test_throws ArgumentError lp(dfb, :f2dlgrgdp, xnames=:dlgrgdp, wnames=ws[2:3],
+        wgnames=ws[1], nlag=3, nhorz=1, iv=:dlgrgdp=>:dlgcpi, panelid=:iso,
+        vce=cluster(:iso), addylag=false, checkrows=false)
+    @test_throws ArgumentError lp(df, :dlgrgdp, wnames=ws, subset=df.year.>1900,
+        checkrows=false)
 end

--- a/test/slp.jl
+++ b/test/slp.jl
@@ -99,7 +99,8 @@ end
     wgs = Any[]
     fes0 = Any[]
     clus0 = Any[]
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing, true)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 3, 0,
+        nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 5)
     @test T1 == T-8
     @test size(res) == (T1, 2)
@@ -107,7 +108,8 @@ end
     @test all(e2)
 
     xs = Any[]
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 0)
     @test T1 == 99
     @test size(res) == (T1, 2)
@@ -117,14 +119,15 @@ end
     ys[1][2], ys[1][3] = NaN, Inf
     xs = Any[convert(Vector{Union{Float64, Missing}}, randn(T))]
     xs[1][3] = missing
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 0,
+        nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 0)
     @test T1 == 96
     @test size(res) == (T1, 2)
     @test e1 == ((1:99).>3)
     @test all(e2)
 
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 1,
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 1, 1,
         ((1:100).<60).|((1:100).>=70), nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 1)
     @test T1 == 83
@@ -134,7 +137,8 @@ end
     ys, xs = Any[randn(T)], Any[randn(T)]
     ss[1][2], ss[1][4] = NaN, Inf
     ws = ys
-    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 2, 0, nothing, nothing, true)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, nothing, clus0, nothing, 2, 0,
+        nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 0)
     @test T1 == 97
     @test all(e1)

--- a/test/slp.jl
+++ b/test/slp.jl
@@ -96,9 +96,10 @@ end
     T = 100
     ys, ss, xs = Any[randn(T)], [randn(T)], Any[randn(T)]
     ws = ys
+    wgs = Any[]
     fes0 = Any[]
     clus0 = Any[]
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 3, 0, nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 5)
     @test T1 == T-8
     @test size(res) == (T1, 2)
@@ -106,7 +107,7 @@ end
     @test all(e2)
 
     xs = Any[]
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 0)
     @test T1 == 99
     @test size(res) == (T1, 2)
@@ -116,14 +117,15 @@ end
     ys[1][2], ys[1][3] = NaN, Inf
     xs = Any[convert(Vector{Union{Float64, Missing}}, randn(T))]
     xs[1][3] = missing
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 0, nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 0)
     @test T1 == 96
     @test size(res) == (T1, 2)
     @test e1 == ((1:99).>3)
     @test all(e2)
 
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 1, 1, ((1:100).<60).|((1:100).>=70), nothing)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 1, 1,
+        ((1:100).<60).|((1:100).>=70), nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 1)
     @test T1 == 83
     @test e1 == ((1:98).>3) .& (((1:98).<58) .| ((1:98).>=70))
@@ -132,7 +134,7 @@ end
     ys, xs = Any[randn(T)], Any[randn(T)]
     ss[1][2], ss[1][4] = NaN, Inf
     ws = ys
-    dt = LPData(ys, xs, ws, nothing, fes0, clus0, nothing, 2, 0, nothing, nothing)
+    dt = LPData(ys, xs, ws, wgs, nothing, fes0, clus0, nothing, 2, 0, nothing, nothing, true)
     res, X, T1, e1, e2 = _makeYSr(dt, ss, 0)
     @test T1 == 97
     @test all(e1)


### PR DESCRIPTION
When data do not contain any invalid rows,  it's now possible to skip the checks by specifying `checkrows=false` with `lp`.

A new keyword argument `wgnames` for `lp` helps specifying lagged control variables that are interacted with `panelid`. Estimation does not involve building full data columns for these interacted variables, although results are numerically identical.

Fixed issues that caused wrong residuals when `panelweight` is specified and estimation involves 2SLS.